### PR TITLE
Fix minor typos

### DIFF
--- a/docs/developers/building/first-contract.md
+++ b/docs/developers/building/first-contract.md
@@ -10,7 +10,7 @@ Follows the same process as deploying to Ethereum
 Gnosis is an EVM based chain, meaning deployment steps are the same as deployment to Ethereum or other chains. Check the [network specifications](/about/networks/).
 
 :::note
-You will also need a [small amount of Gnosis](/tools/faucets) to deploy a contract, and for any contract functions.
+You will also need a [small amount of xDai](/tools/faucets) to deploy a contract, and for any contract functions.
 For testing purposes, it is recommended to first deploy to [Chiado testnet](/about/networks/chiado). After functionality is tested and confirmed, deploy to Gnosis mainnet!
 :::
 

--- a/docs/tools/faucets/README.md
+++ b/docs/tools/faucets/README.md
@@ -5,7 +5,7 @@
 
 A faucet is a service that provides small amounts of [xDai tokens](/about/tokens/xdai) to users who are experimenting with Gnosis. Here is a list of the available faucets.
 
-## Oficial Faucet
+## Official Faucet
 
 - [Gnosis Faucet](https://gnosisfaucet.com/)
 


### PR DESCRIPTION
## What

- Fix minor typo
- Replace "Gnosis" with "xDai" as being required for contract deployment.

## Refs