### PR TITLE
Fix GOOGLE_ANALYTICS_ID for main branch

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,6 +13,9 @@ on:
   release:
     types: [published]
 
+env:
+
+
 jobs:
   deploy:
     name: Deployment
@@ -49,7 +52,8 @@ jobs:
           yarn install
           pip install awscli --upgrade --user
 
-      - name: Sets Google Analytics
+      - name: Sets Google Analytics for main
+        if: github.ref == 'refs/heads/main'
         env:
           GOOGLE_ANALYTICS_ID: ${{ secrets.STAGING_GOOGLE_ANALYTICS_ID }}
         run: |


### PR DESCRIPTION
  - Set environment variable `GOOGLE_ANALYTICS_ID` only for `main` branch for Staging deployment with the right Google
    Analytics value.