### PR TITLE
Added Chainstack to providers list

### DIFF
--- a/docs/tools/rpc/README.mdx
+++ b/docs/tools/rpc/README.mdx
@@ -89,3 +89,4 @@ WebSockets are recommended to push new logs as available.
 - [Blast](https://blastapi.io/public-api/gnosis)
 - [GetBlock](https://getblock.io/)
 - [Pokt](https://docs.pokt.network/home/use/public-rpc/gnosis-chain)
+- [Chainstack](https://chainstack.com/build-better-with-gnosis-chain/)


### PR DESCRIPTION
## What

Chainstack now supports [Gnosis chain](https://chainstack.com/build-better-with-gnosis-chain/) and I have added it to the providers' list. 

## Refs
