### PR TITLE
Add line breaks to Lighthouse VC docs

### DIFF
--- a/docs/node/guide/validator/_partials/clients/_install_validator_lighthouse.md
+++ b/docs/node/guide/validator/_partials/clients/_install_validator_lighthouse.md
@@ -44,8 +44,8 @@ echo 'PLACE_HERE_YOUR_PASSWORD' > keystores/validator_keys/password.txt
 
 ```shell
 ./lighthouse validator_client \
-    --network gnosis \ 
-    --validators-dir validators \ 
+    --network gnosis \
+    --validators-dir validators \
     --enable-doppelganger-protection \
 # highlight-start
     --graffiti "gnosis-docs-graffiti" # Change this value 

--- a/docs/node/guide/validator/_partials/clients/_install_validator_lighthouse.md
+++ b/docs/node/guide/validator/_partials/clients/_install_validator_lighthouse.md
@@ -43,10 +43,10 @@ echo 'PLACE_HERE_YOUR_PASSWORD' > keystores/validator_keys/password.txt
 * Start your lighhouse validator:
 
 ```shell
-./lighthouse validator_client 
-    --network gnosis 
-    --validators-dir validators 
-    --enable-doppelganger-protection  
+./lighthouse validator_client \
+    --network gnosis \ 
+    --validators-dir validators \ 
+    --enable-doppelganger-protection \
 # highlight-start
     --graffiti "gnosis-docs-graffiti" # Change this value 
 # highlight-end


### PR DESCRIPTION
## What

Add `\` line breaks to the Lighthouse VC docs. Presently, if a user copy-pastes this command it won't work. Additionally, other commands have line breaks so this makes things more consistent.

## Refs

- Raised as an issue by another user in the Lighthouse Discord channel: https://discord.com/channels/605577013327167508/746918775919738893/1047334188157775925