### PR TITLE
Add Etherspot SDK

### DIFF
--- a/docs/ecosystems/infrastructure.md
+++ b/docs/ecosystems/infrastructure.md
@@ -37,3 +37,4 @@ keywords: [Gnosis, Chain, Crypto, Ethereum, 1Hive, WrapETH, Punk Domains, Origin
 
 * [Cardstack](https://cardstack.com): Building the Collaborative OS for Web3
 
+* [Etherspot](https://etherspot.io): Multi-chain self-custody Smart Contract Wallet platform that provides solutions for dApps, game and wallet developers to deliver frictionless Web3 UX


### PR DESCRIPTION
## What

Adding Etherspot SDK to ecosystem page. Etherspot supportsGnosis/xDai chain from a while ago. 

Web: https://etherspot.io/  
Docs: https://docs.etherspot.dev/  
Email: [marketing@etherspot.io](mailto:marketing@etherspot.io)