### PR TITLE
Update broken link for Chiado

### DIFF
--- a/docs/node/tools/sedge.md
+++ b/docs/node/tools/sedge.md
@@ -10,7 +10,7 @@ Instructions to get started with Nethermind Sedge found [here](https://docs.sedg
 
 **For Chiado Test network:**
 
-Instructions for Chiado Test Network can be found [here](https://docs.sedge.nethermind.io/docs/quickstart/chiado) 
+Instructions for Chiado Test Network can be found [here](https://docs.sedge.nethermind.io/docs/networks/chiado) 
 
 
 ```mdx-code-block


### PR DESCRIPTION
chiado docs link no longer resolves, I replaced the link with the current working URL https://docs.sedge.nethermind.io/docs/networks/chiado

## What
chiado docs link https://docs.sedge.nethermind.io/docs/quickstart/chiado no longer resolves 
- (describe the changes in detail)
Replaced broken link for the nethermind sedge chiado instructions to a link that does resolve  https://docs.sedge.nethermind.io/docs/networks/chiado

## Refs

- (only fixing a minor bug - broken link, typo - an issue is not needed)
