### PR TITLE
Add Hologram to NFT Project

### DIFF
--- a/docs/ecosystems/nfts.md
+++ b/docs/ecosystems/nfts.md
@@ -38,4 +38,4 @@ keywords: [DeFi, DApps, Gnosis Chain, NFTs, Unique One Network, Foundation, Nift
 * [NFBeez](https://www.nfbeez.xyz/): The first open and decentralized NFT project made by members of 
 1HiveOrg
 
-
+* [Hologram AI Art](https://tryhologram.art/): Experience captivating AI art. Discover Hologram, where 'Holograms' come alive. Share favorites on social media, anticipate NFT integration. Rediscover joy of AI art!


### PR DESCRIPTION
## What

- Add Hologram Project to NFT List

## Refs
- Hologram is a platform that uses AI to generate art and turn it into NFT
- We had our Twitter Space with Gnosis Builders https://twitter.com/gnosisbuilders/status/1668647423064051712?s=20