### PR TITLE
docs: fix typos

### DIFF
--- a/docs/developers/README.md
+++ b/docs/developers/README.md
@@ -30,7 +30,7 @@ Transaction fees are assessed for any Gnosis transactions such as sending xDai t
 <box href="/tools/wallets" title="Wallets">Download a wallet to start using Gnosis.</box>
 <box href="/tools/faucets" title="Faucets">Free fund your wallet with xDai to pay fees.</box>
 <box href="/tools/explorers" title="Explorers">See your transactions, accounts, blocks, and more tools.</box>
-<box href="/tools/rpc" title="RPC Providers">Connect your development evironment and wallets to a public RPC node.</box>
+<box href="/tools/rpc" title="RPC Providers">Connect your development environment and wallets to a public RPC node.</box>
 <box href="/node" title="Run a Node">Setup and run your own node.</box>
 <box href="/developers/smart-contracts/" title="Dev Tools">Setup your development environment.</box>
 <box href="/developers/building/first-contract" title="Tutorials">Learn how to build dApps.</box>

--- a/docs/developers/building/full-stack-dapp.md
+++ b/docs/developers/building/full-stack-dapp.md
@@ -9,7 +9,7 @@ keywords: [deploy dapp, full stack app, tutorial, web3, dapp development]
 
 In the following tutorial we will go through a step-by-step guide on how to create a full-stack Hello World App that interacts with Gnosis. This tutorial is designed for either new developers interested in Dapp development or existing devs interested in migrating to Gnosis development.
 
-Throughout the tutorial, feel free to refrence other pages in our documentation for information with greater depth - however this tutorial will give you a basic understand of how to get up and running.
+Throughout the tutorial, feel free to reference other pages in our documentation for information with greater depth - however this tutorial will give you a basic understand of how to get up and running.
 
 This Dapp will allow you to wave at Gnosis, and see how many times you have waved.
 
@@ -179,7 +179,7 @@ module.exports = {
 };
 ```
 :::danger
-Proper private key management is critical. To safeguard your private key, it has been added to a .env file, or enviornment variable file. DO NOT PUSH THIS TO GITHUB OR COMMIT TO SOURCE CONTROL. Even if you delete it after, assume it will live on forever after being committed and is compromised. Add .env to your .gitignore if you plan on committing, or store securely it in an environment variable.
+Proper private key management is critical. To safeguard your private key, it has been added to a .env file, or environment variable file. DO NOT PUSH THIS TO GITHUB OR COMMIT TO SOURCE CONTROL. Even if you delete it after, assume it will live on forever after being committed and is compromised. Add .env to your .gitignore if you plan on committing, or store securely it in an environment variable.
 :::
 
 Lets install dotenv, to safekeep your private key:
@@ -189,7 +189,7 @@ npm install --save dotenv
 ```
 
 :::note
-Make sure to refresh your console/terminal afterwards, to make sure you have dotenv in your current enviornment.
+Make sure to refresh your console/terminal afterwards, to make sure you have dotenv in your current environment.
 :::
 
 **Create a .env file in your root directory**
@@ -258,7 +258,7 @@ To get your front end up and running quickly, vist this [Replit link](https://re
 
 Navigate to the ```App.jsx``` file in Replit and follow the directions below:
 
-To connect **your contract** with your front end, replace the contract address variable shown below with the contract address you recieved after deploying.
+To connect **your contract** with your front end, replace the contract address variable shown below with the contract address you received after deploying.
 
 ```js showLineNumbers title=src/App.jsx
 const App = () => {

--- a/docs/developers/smart-contracts/foundry.md
+++ b/docs/developers/smart-contracts/foundry.md
@@ -100,6 +100,6 @@ forge create --rpc-url https://rpc.gnosischain.com \
 </TabItem>
 </Tabs>
 
-For information regarding pre-existing contract verification, visit the [offical Forge documentation](https://book.getfoundry.sh/forge/deploying#verifying-a-pre-existing-contract).
+For information regarding pre-existing contract verification, visit the [official Forge documentation](https://book.getfoundry.sh/forge/deploying#verifying-a-pre-existing-contract).
 
 For further Contract Verification information, visit our [official page](/developers/verify/)

--- a/docs/developers/smart-contracts/hardhat.md
+++ b/docs/developers/smart-contracts/hardhat.md
@@ -210,4 +210,4 @@ Visit our [Contract Verification Page](/developers/verify/) for more documentati
 
 ## Additional Hardhat Documentation
 
-- Additonal Hardhat deployment documentation is located [here](https://hardhat.org/hardhat-runner/docs/guides/deploying).
+- Additional Hardhat deployment documentation is located [here](https://hardhat.org/hardhat-runner/docs/guides/deploying).

--- a/docs/developers/smart-contracts/truffle.mdx
+++ b/docs/developers/smart-contracts/truffle.mdx
@@ -105,8 +105,8 @@ Visit our [Tools page](/tools) for other support.
 
 Verify with Truffle by using [Truffle Plugin Verify](https://trufflesuite.com/docs/truffle/reference/truffle-commands/#deploy)
 
-Visit our [Contract Verfication Page](/developers/verify/) for more documentation on verification tools.
+Visit our [Contract Verification Page](/developers/verify/) for more documentation on verification tools.
 
 ## Additional Truffle Documentation
 
-- Additonal Truffle command documenation is located [here](https://trufflesuite.com/docs/truffle/reference/truffle-commands/#deploy).
+- Additional Truffle command documenation is located [here](https://trufflesuite.com/docs/truffle/reference/truffle-commands/#deploy).

--- a/docs/node/guide/validator/_partials/_generate_validator_keys_cli.md
+++ b/docs/node/guide/validator/_partials/_generate_validator_keys_cli.md
@@ -84,7 +84,7 @@ Learn more about [keys](https://kb.beaconcha.in/ethereum-2-keys) and [withdrawal
 - Create a password to encrypt the keys.
 - The mnemonic (seed phrase) will show on screen. Save it in a secure place (idealy offline).
 - Type your mnemonic to confirm in the tool.
-- Wait untill the keys are created. Two types of files will be generated: 
+- Wait until the keys are created. Two types of files will be generated: 
     - `deposit_data-*.json`
     - One `keystore-*.json` per validator
 - Save the location of the generated keys, and copy them in a backup USB memory or any other secure storage.

--- a/docs/tools/README.md
+++ b/docs/tools/README.md
@@ -9,7 +9,7 @@ keyworkds: [gnosis tools, dev tools, wallets, faucet, gnosis explorer, rpc provi
 <box href="/tools/wallets" title="Wallets">Download a wallet to start using Gnosis.</box>
 <box href="/tools/faucets" title="Faucets">Free fund your wallet with xDai to pay fees.</box>
 <box href="/tools/explorers" title="Explorers">See your transactions, accounts, blocks, and more tools.</box>
-<box href="/tools/rpc" title="RPC Providers">Connect your development evironment and wallets to a public RPC node.</box>
+<box href="/tools/rpc" title="RPC Providers">Connect your development environment and wallets to a public RPC node.</box>
 </div>
 
 ## Featured Tutorials

--- a/docs/tools/beacon-chain/liquid-staking.md
+++ b/docs/tools/beacon-chain/liquid-staking.md
@@ -63,6 +63,6 @@ The interface shows the time until the next update to your rGNO.
 :::note
 **Coming Soon**: Use your rGNO in DeFi protocols on Gnosis to borrow and stake additional GNO! 
 
-Since rGNO tokens represent your rewards in a StakeWise Pool, exchanging or transfering your rGNO will mean that you transferred your rewards to someone else. It will not impact your future earnings.
+Since rGNO tokens represent your rewards in a StakeWise Pool, exchanging or transferring your rGNO will mean that you transferred your rewards to someone else. It will not impact your future earnings.
 :::
 


### PR DESCRIPTION
Hey :wave:,

This PR will fix :

1 typo in `docs/developers/README.md`
4 typos in `docs/developers/building/full-stack-dapp.md`
1 typo in `docs/developers/smart-contracts/foundry.md`
1 typo in `docs/developers/smart-contracts/hardhat.md`
2 typos in `docs/developers/smart-contracts/truffle.mdx`
1 typo in `docs/node/guide/validator/_partials/_generate_validator_keys_cli.md`
1 typo in `docs/tools/README.md`
1 typo in `docs/tools/beacon-chain/liquid-staking.md`


Best!