### PR TITLE
Fix execution change POST URL

### DIFF
--- a/docs/node/management/withdrawals.md
+++ b/docs/node/management/withdrawals.md
@@ -138,7 +138,7 @@ This option is only recommended for advanced user. Please use it at your own ris
    Run the following command.
 
 ```
-curl -d @change-operations.json -H "Content-Type: application/json"  -X POST 127.0.0.1:<beacon_node_port>/eth/v1/beacon/pool/bls_to_execution_change
+curl -d @change-operations.json -H "Content-Type: application/json"  -X POST http://127.0.0.1:<beacon_node_port>/eth/v1/beacon/pool/bls_to_execution_changes
 ```
 
 ```mdx-code-block


### PR DESCRIPTION
## What

- Use the correct `/eth/v1/beacon/pool/bls_to_execution_changes` URL in the withdrawals guide.

## Refs

- See API spec: https://ethereum.github.io/beacon-APIs/#/Beacon/submitPoolBLSToExecutionChange