### PR TITLE
Fix some minor typo

### DIFF
--- a/docs/bridges/audits.md
+++ b/docs/bridges/audits.md
@@ -12,14 +12,14 @@ The OmniBridge and xDai Bridge have undergone multiple independent security audi
 
 **Completed**: August 31, 2023  
 **Conclusion**: 2 medium issues, 5 low risk issues, 3 info issues. All issues has been resolved.  
-**Contracts**: hhttps://github.com/gnosischain/tokenbridge-contracts/tree/xdaibridge-upgrade-sdai  
+**Contracts**: https://github.com/gnosischain/tokenbridge-contracts/tree/xdaibridge-upgrade-sdai  
 **Audit Report**: [Omega Gnosis Bridge Final Audit Report](../../static/files/Omega%20-%20Gnosis%20Bridge%20-%20final%20report.pdf)
 
 ### ChainSafe
 
 **Completed**: August 31, 2023  
 **Conclusion**: 2 minor issues, 2 optimizational issues.  
-**Contracts**:https://github.com/gnosischain/tokenbridge-contracts/tree/xdaibridge-upgrade-sdai  
+**Contracts**: https://github.com/gnosischain/tokenbridge-contracts/tree/xdaibridge-upgrade-sdai  
 **Audit Report**: [ChainSafe Audit Report](../../static/files/dai-xdai-08-23.pdf)
 
 **Reference**: [Savings xDAI](../bridges/tokenbridge/xdai-bridge.md#savings-xdai)

--- a/docs/developers/account-abstraction/safe.md
+++ b/docs/developers/account-abstraction/safe.md
@@ -40,7 +40,7 @@ Relay Kit allows users to pay transaction fees (gas fees) using the native block
 
 Currently, the Relay Kit is only compatible with [Gelato relay](https://docs.gelato.network/developer-services/relay). There are two ways to use Gelato relay:
 1. [Gelato 1Balance](https://docs.gelato.network/developer-services/relay/payment-and-fees/1balance-and-relay): Using prepaid deposit(via USDC on Polygon for mainnet, via gETH on Goerli for testnet) to funds the 1Balance account.With the deposit on 1Balance account, the Relay Kit can sponsors a transactions to other Safe within or on another chain. 
-2. [Gelato SyncFee](https://docs.gelato.network/developer-services/relay/non-erc-2771/callwithsyncfee): Allows you to execute a transaction and pay the gas fees directly with funds in your Safe, even if you don't have ETH on Ethrereum or xDAI on Gnosis Chain.
+2. [Gelato SyncFee](https://docs.gelato.network/developer-services/relay/non-erc-2771/callwithsyncfee): Allows you to execute a transaction and pay the gas fees directly with funds in your Safe, even if you don't have ETH on Ethereum or xDAI on Gnosis Chain.
 
 
 Follow the [tutorial on Safe](https://docs.safe.global/learn/safe-core/safe-core-account-abstraction-sdk/relay-kit#quickstart) to send some tokens to another address using the Relay Kit to pay for he gas fees. 


### PR DESCRIPTION
## What

- Some minor typos are fixed

1. audits.md: fix a hyperlink
2. safe.md: "Ethrereum" corrected to "Ethereum".

## Refs