### PR TITLE
Remove dappnode.io checkpoint sync provider

### DIFF
--- a/docs/about/networks/mainnet.md
+++ b/docs/about/networks/mainnet.md
@@ -42,7 +42,6 @@ keywords:
 | Beacon Explorer Backup 2 | https://beacon-v2.gnosischain.com           |
 | Beacon Checkpoint Sync   | https://checkpoint.gnosis.gateway.fm        |
 | Beacon Checkpoint Sync   | https://checkpoint.gnosischain.com          |
-| Beacon Checkpoint Sync   | https://checkpoint-sync-gnosis.dappnode.io/ |
 
 ### Other Tools
 


### PR DESCRIPTION
## What

- Remove `https://checkpoint-sync-gnosis.dappnode.io/` from list of checkpoint sync providers as it is no longer available

## Refs

### Actual:
```shell
$ curl https://checkpoint-sync-gnosis.dappnode.io

{"code":404,"message":"NOT_FOUND","stacktraces":[]}
```

### Expected:

The site to load similar to https://checkpoint.gnosis.gateway.fm