### PR TITLE
Update voluntary-exit.md with Dappnode instructions

### DIFF
--- a/docs/node/management/voluntary-exit.md
+++ b/docs/node/management/voluntary-exit.md
@@ -10,7 +10,13 @@ Voluntary exit procedures vary depending on your client.
 
 :::caution
 Exits are non-reversible; once you have exited you cannot restart your validator.
+
+You must have a `0x01` type withdrawal address before exiting your validator [withdrawal credentials](withdrawals.md#check-withdrawal-credential). 
 :::
+
+### Dappnode
+
+Navigate to the Stakers > Gnosis Chain menu, click on the "Upload Keystores" button on the Web3Signer card. Once you are in the Web3Signer UI, select the validators you want to exit and click on the "Exit Validator" button on the top right part of the UI. Follow the instructions and type `I want to exit`, followed then click the "Exit" button. More informations in [Dappnode Docs](https://docs.dappnode.io/docs/user/staking/gnosis-chain/solo#1-exit-the-validator-from-the-dappnode-ui).
 
 ### Lighthouse
 

--- a/docs/node/management/voluntary-exit.md
+++ b/docs/node/management/voluntary-exit.md
@@ -16,7 +16,9 @@ You must have a `0x01` type withdrawal address before exiting your validator [wi
 
 ### Dappnode
 
-Navigate to the Stakers > Gnosis Chain menu, click on the "Upload Keystores" button on the Web3Signer card. Once you are in the Web3Signer UI, select the validators you want to exit and click on the "Exit Validator" button on the top right part of the UI. Follow the instructions and type `I want to exit`, followed then click the "Exit" button. More informations in [Dappnode Docs](https://docs.dappnode.io/docs/user/staking/gnosis-chain/solo#1-exit-the-validator-from-the-dappnode-ui).
+Navigate to the Stakers > Gnosis Chain menu, click on the "Upload Keystores" button on the Web3Signer card. Once you are in the Web3Signer UI, select the validators you want to exit and click on the "Exit Validator" button on the top right part of the UI. Follow the instructions and type `I want to exit`, followed then click the "Exit" button. 
+
+- For more info, see the [Dappnode Docs](https://docs.dappnode.io/docs/user/staking/gnosis-chain/solo#1-exit-the-validator-from-the-dappnode-ui).
 
 ### Lighthouse
 


### PR DESCRIPTION
## What

- Added some missing informations about how to exit when the validator runs on Dappnode
- Added an extra warning in the "caution" section about needing a 0x01 withdrawal address before exiting

## Refs

The extra warning doesn't hurt I think, we've seen unfortunate situations where people exited their validator with a 0x00 withdrawal address.