### PR TITLE
Remove DinoWallet

### DIFF
--- a/docs/tools/wallets/README.md
+++ b/docs/tools/wallets/README.md
@@ -21,7 +21,6 @@ Visit [Gnosis Wallets](https://gnosiswallets.com/) to find a wallet that fits yo
 - [Ambire Wallet](https://www.ambire.com/)
 - [Coinbase Wallet](https://www.coinbase.com/wallet)
 - [DEX Wallet](https://www.dexwallet.io/)
-- [DinoWallet](https://dinowallet.org/)
 - [Enkrypt](https://www.enkrypt.com/?mtm_campaign=Gnosis%20Chain%20Wallet%20Wiki&mtm_kwd=Wiki)
 - [Frame](https://frame.sh/)
 - [Mt Pelerin](https://www.mtpelerin.com/bridge-wallet)

--- a/sidebars.js
+++ b/sidebars.js
@@ -485,11 +485,6 @@ const sidebars = {
                 },
                 {
                   type: "link",
-                  label: "DinoWallet",
-                  href: "https://dinowallet.org/",
-                },
-                {
-                  type: "link",
                   label: "Frame",
                   href: "https://frame.sh/",
                 },


### PR DESCRIPTION
## What

1. The web site no longer accessible - https://dinowallet.org/ 
2. Twitter last Tweet was November 23, 2021 - https://twitter.com/DinoWalletApp
3. DinoWallet no longer listed in Playstore - https://play.google.com/store/apps/details?id=com.dino.wallet

## Refs

- (this project accepts pull requests related to open issues)
- (if suggesting a new feature or change, please discuss it in an issue first)
- (if fixing a bug, there should be an issue describing it with steps to reproduce)
- (only fixing a minor bug - broken link, typo - an issue is not needed)
- (please link to the issue here)