### PR TITLE
hhttps -> https

### DIFF
--- a/docs/bridges/tutorials/using-amb.md
+++ b/docs/bridges/tutorials/using-amb.md
@@ -41,5 +41,5 @@ The process of claiming the message from Chiado to Goerli works similarly to the
 
 ## Deploying custom ERC-20 Bridge
 
-- [Tokenbridge Docs: Deploying custom token bridge on top of AMB](hhttps://docs.tokenbridge.net/eth-xdai-amb-bridge/erc20-to-erc20-extension-linked-with-a-particular-token/deploy-erc20-erc677-erc827-to-erc677-amb-bridge-extension)
+- [Tokenbridge Docs: Deploying custom token bridge on top of AMB](https://docs.tokenbridge.net/eth-xdai-amb-bridge/erc20-to-erc20-extension-linked-with-a-particular-token/deploy-erc20-erc677-erc827-to-erc677-amb-bridge-extension)
 - [Tokenbridge Docs: Deplying a custom UI token bridge on top of AMB](https://docs.tokenbridge.net/eth-xdai-amb-bridge/erc20-to-erc20-extension-linked-with-a-particular-token/ui-to-transfer-tokens-through-amb)


### PR DESCRIPTION
## What

- Broken link because of typo (hhttps instead of https)

## Refs

- (this project accepts pull requests related to open issues)
- (if suggesting a new feature or change, please discuss it in an issue first)
- (if fixing a bug, there should be an issue describing it with steps to reproduce)
- (only fixing a minor bug - broken link, typo - an issue is not needed)
- (please link to the issue here)