### PR TITLE
Remove "in progress" from Erigon

### DIFF
--- a/docs/node/architecture.md
+++ b/docs/node/architecture.md
@@ -36,8 +36,8 @@ Gnosis Execution Layer is the legacy xDai "Eth1" network. The Execution Layer is
 Node Operators will need to run an Execution Layer client, which will interact with the Execution Layer network.
 
 - [Nethermind](./manual/execution/nethermind.md)
+- [Erigon](./manual/execution/erigon.md)
 - [Geth](./manual/execution/geth.md) (in progress)
-- [Erigon](./manual/execution/erigon.md) (in progress)
 
 Gnosis used to be supported by the [Parity OpenEthereum client](./manual/execution/openethereum.md), but it has since been deprecated.
 


### PR DESCRIPTION

## What

- Erigon seems to be ready to be used, so I removed the "in progress" comment next to it in `architecture.md`

## Refs

- [Erigon's page in these docs](https://docs.gnosischain.com/node/manual/execution/erigon) state it is ready for production usage already.
- Unlike, e.g. [Geth](https://docs.gnosischain.com/node/manual/execution/geth)