### PR TITLE
correct fee on gnosis->mainnet omnibridge

### DIFF
--- a/docs/bridges/tokenbridge/omnibridge.md
+++ b/docs/bridges/tokenbridge/omnibridge.md
@@ -86,7 +86,7 @@ The Omnibridge mints bridged tokens using a variant of the [ERC-677](https://git
 | Token            | Ethereum -> Gnosis | Gnosis -> Ethereum |
 | ---------------- | ------------------ | ------------------ |
 | Approx. Gas Cost |                    |                    |
-| Bridge Fees      | 0%                 | 0%                 |
+| Bridge Fees      | 0%                 | 0.1%               |
 
 #### Single Transaction Limits
 


### PR DESCRIPTION
## Refs

feeManager reference: https://gnosisscan.io/address/0xf6A78083ca3e2a662D6dd1703c939c8aCE2e268d#readProxyContract#F6
reading feeManager: https://gnosisscan.io/address/0x5dbc897aef6b18394d845a922bf107fa98e3ac55#readContract
sample with xPNK token, address https://gnosisscan.io/token/0x37b60f4e9a31a64ccc0024dce7d0fd07eaa0f7b3

<img width="1125" alt="image" src="https://github.com/gnosischain/documentation/assets/40367733/c8e54324-c531-4bde-8db3-2e61d8359501">

likely outdated docs since fee is reproduced with:
- 0xe91d153e0b41518a2ce8dd3d7944fa863463a97d (wxdai)
- 0x6c76971f98945ae98dd7d4dfca8711ebea946ea6 (wsteth)