### PR TITLE
Update Nethermind executable name

### DIFF
--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -286,7 +286,7 @@ Please keep in mind that this is just a basic example, all other settings will b
 Nethermind offers various [installation options](https://docs.nethermind.io/nethermind/first-steps-with-nethermind/getting-started). The package comes with various binaries, including a Launcher with a guided setup, which will help you to create the configuration interactively. Alternatively, you find Runner which is the executable itself and you can just run it with config flags. JSON RPC is enabled by default.
 
 ```
-Nethermind.Runner --config gnosis \
+nethermind --config gnosis \
     --datadir /data/gnosis \
     --JsonRpc.JwtSecretFile=/path/to/jwtsecret
 ```

--- a/docs/node/manual/execution/_partials/_install_el_nethermind.md
+++ b/docs/node/manual/execution/_partials/_install_el_nethermind.md
@@ -36,7 +36,7 @@ import TabItem from '@theme/TabItem';
 
 - Execute Nethermind
     ```shell
-    ./Nethermind.Runner \
+    ./nethermind \
         --config gnosis \
         --JsonRpc.Enabled true \
         --HealthChecks.Enabled true \
@@ -59,7 +59,7 @@ import TabItem from '@theme/TabItem';
 
 - Run the following command:
     ```shell
-    .\Nethermind.Runner.exe \
+    ./nethermind \
         --config gnosis \
         --JsonRpc.Enabled true \
         --HealthChecks.Enabled true \
@@ -103,7 +103,7 @@ import TabItem from '@theme/TabItem';
 
 - Execute Nethermind
     ```shell
-    ./Nethermind.Runner \
+    ./nethermind \
         --config chiado \
         --JsonRpc.Enabled true \
         --HealthChecks.Enabled true \
@@ -126,7 +126,7 @@ import TabItem from '@theme/TabItem';
 
 - Run the following command:
     ```shell
-    .\Nethermind.Runner.exe \
+    ./nethermind \
         --config chiado \
         --JsonRpc.Enabled true \
         --HealthChecks.Enabled true \

--- a/docs/node/manual/execution/nethermind.md
+++ b/docs/node/manual/execution/nethermind.md
@@ -159,10 +159,10 @@ Nethermind has ‘Nethermind launcher’ an easy GUI where you can configure you
 Windows
 ```
 # Gnosis Mainnet
-./Nethermind.Runner --config gnosis --JsonRpc.JwtSecretFile=<PATH to jwt.hex>
+./nethermind --config gnosis --JsonRpc.JwtSecretFile=<PATH to jwt.hex>
 
 # Chiado Testnet
-./Nethermind.Runner --config chiado --JsonRpc.JwtSecretFile=<PATH to jwt.hex>
+./nethermind --config chiado --JsonRpc.JwtSecretFile=<PATH to jwt.hex>
 ```
 
 Linux and MAC

--- a/updates/2022/12-08-temporary-bootnodes.md
+++ b/updates/2022/12-08-temporary-bootnodes.md
@@ -35,8 +35,8 @@ Nethermind utilizes the flag [`--Discovery.Bootnodes`](https://github.com/Nether
 Docs: [Nethermind Github](https://github.com/NethermindEth/nethermind/blob/3734ff4c150cd177958395e34e731e15d051e1fd/src/Nethermind/Nethermind.Init/Steps/UpdateDiscoveryConfig.cs#L37)
 
 ```
-Nethermind.Runner
-    --config xDai
+nethermind
+    --config gnosis
     --Discovery.Bootnodes ...   # comma separated enode addresses
 ```
 


### PR DESCRIPTION
## What

Updated the Nethermind executable name changed in v1.21.0. Although, `Nethermind.Runner` still works as a symlink on Linux and macOS; it may be dropped in future versions.
