### PR TITLE
Update Lodestar documentation references

### DIFF
--- a/docs/node/management/migrating-validator.md
+++ b/docs/node/management/migrating-validator.md
@@ -65,7 +65,7 @@ Import an interchange file to the slashing protection DB:
 validator slashing-protection import --network gnosis --file interchange.json
 ```
 
-- For more info, see the [Lodestar Command Line Reference doc](https://chainsafe.github.io/lodestar/reference/cli/#validator-slashing-protection).
+- For more info, see the [Lodestar Command Line Reference doc](https://chainsafe.github.io/lodestar/validator-management/validator-cli/#validator-slashing-protection-import).
 
 ## Nimbus
 

--- a/docs/node/management/monitoring-node.md
+++ b/docs/node/management/monitoring-node.md
@@ -68,8 +68,8 @@ https://github.com/sigp/lighthouse-metrics
     --metrics=true
     --metrics.port=<PORT>
 
-https://chainsafe.github.io/lodestar/usage/prometheus-grafana/
-https://chainsafe.github.io/lodestar/reference/cli/#validator
+https://chainsafe.github.io/lodestar/logging-and-metrics/prometheus-grafana/
+https://chainsafe.github.io/lodestar/beacon-management/beacon-cli/#-metrics
 </TabItem>
 <TabItem value="Teku" label="Teku">
 

--- a/docs/node/management/voluntary-exit.md
+++ b/docs/node/management/voluntary-exit.md
@@ -38,7 +38,7 @@ Follow the syntax of the Lodestar CLI commands and their options.
 validator voluntary-exit --network gnosis --pubkeys 0xF00
 ```
 
-- For more info, see the [Lodestar Command Line Reference doc](https://chainsafe.github.io/lodestar/validator-management/validator-cli/#validator-voluntary-exit-examples).
+- For more info, see the [Lodestar Command Line Reference doc](https://chainsafe.github.io/lodestar/validator-management/validator-cli/#validator-voluntary-exit).
 
 ### Nimbus
 

--- a/docs/node/manual/beacon/lodestar.md
+++ b/docs/node/manual/beacon/lodestar.md
@@ -56,7 +56,7 @@ $ lodestar beacon
 
 :::info More about Checkpoint Sync
 
-- Lodestar's [Checkpoint Sync docs](https://chainsafe.github.io/lodestar/usage/beacon-management/#checkpoint-sync)
+- Lodestar's [Checkpoint Sync docs](https://chainsafe.github.io/lodestar/getting-started/starting-a-node/#checkpoint-sync)
 - Gnosis' [Checkpoint Sync server Status](https://checkpoint.gnosischain.com/)
 
 :::

--- a/docs/node/manual/validator/_partials/clients/_install_validator_lodestar.md
+++ b/docs/node/manual/validator/_partials/clients/_install_validator_lodestar.md
@@ -48,9 +48,9 @@ You can import the keys when starting the validator.
 ```
 
 Replace `suggestedFeeRecipient` with your Gnosis address. This fee recipient address will receive tips from user transactions from the block the validator proposed. If not set, the tips will be sent to zero address, that is burnt completely. It is strongly recommended that you configure this value in your setup.
-Learn more about [suggestedFeeRecipient](https://chainsafe.github.io/lodestar/usage/validator-management/#configuring-the-fee-recipient-address) flag in Lodestar docs.
+Learn more about [suggestedFeeRecipient](https://chainsafe.github.io/lodestar/validator-management/vc-configuration/#configuring-the-fee-recipient-address) flag in Lodestar docs.
 
-Replace `graffiti` with your own [graffiti](https://chainsafe.github.io/lodestar/reference/cli/). It is an optional field that can be used to add a message to the [block](https://ethereum.org/en/developers/docs/blocks/) by the proposer.
+Replace `graffiti` with your own [graffiti](https://chainsafe.github.io/lodestar/validator-management/validator-cli/#-graffiti). It is an optional field that can be used to add a message to the [block](https://ethereum.org/en/developers/docs/blocks/) by the proposer.
 
 
 

--- a/docs/node/manual/validator/run/lodestar.md
+++ b/docs/node/manual/validator/run/lodestar.md
@@ -96,9 +96,9 @@ GRAFFITI=gnosischain/lodestar
 ```
 
 Replace `suggestedFeeRecipient` with your Gnosis address. This fee recipient address will receive tips from user transactions from the block the validator proposed. If not set, the tips will be sent to zero address, that is burnt competely. It is strongly recommended that you configure this value in your setup.
-Learn more about [suggestedFeeRecipient](https://chainsafe.github.io/lodestar/usage/validator-management/#configuring-the-fee-recipient-address) flag in Lodestar docs.
+Learn more about [suggestedFeeRecipient](https://chainsafe.github.io/lodestar/validator-management/vc-configuration/#configuring-the-fee-recipient-address) flag in Lodestar docs.
 
-Replace `graffiti` with your own [graffiti](https://chainsafe.github.io/lodestar/reference/cli/). It is an optional field that can be used to add a message to the [block](https://ethereum.org/en/developers/docs/blocks/) by the proposer.
+Replace `graffiti` with your own [graffiti](https://chainsafe.github.io/lodestar/validator-management/validator-cli/#-graffiti). It is an optional field that can be used to add a message to the [block](https://ethereum.org/en/developers/docs/blocks/) by the proposer.
 
 ### 4. Keystore Location
 

--- a/updates/2022/12-08-temporary-bootnodes.md
+++ b/updates/2022/12-08-temporary-bootnodes.md
@@ -106,9 +106,9 @@ lighthouse
 
 ### Lodestar
 
-Lodestar utilizes multiple [`--bootnodes`](https://chainsafe.github.io/lodestar/reference/cli/#beacon) flags to specify custom bootnodes. 
+Lodestar utilizes multiple [`--bootnodes`](https://chainsafe.github.io/lodestar/beacon-management/beacon-cli/#-bootnodes) flags to specify custom bootnodes. 
 
-Docs: https://chainsafe.github.io/lodestar/reference/cli/#beacon
+Docs: https://chainsafe.github.io/lodestar/beacon-management/networking/#peer-discovery-discv5
 
 ```
 lodestar


### PR DESCRIPTION
Update Lodestar documentation references, for flags we can now directly deep link instead of just to the CLI page, and also fixed a bunch of links of pages that got moved in docs refactor.