### PR TITLE
fix: using datadir instead of validator-dir

### DIFF
--- a/docs/node/manual/validator/run/lighthouse.md
+++ b/docs/node/manual/validator/run/lighthouse.md
@@ -60,7 +60,7 @@ services:
       lighthouse
       validator_client
       --network=gnosis
-      --datadir=/data/validators
+      --validators-dir=/data/validators
       --beacon-nodes=http://consensus:4000
       --graffiti=$GRAFFITI
       --debug-level=info


### PR DESCRIPTION
## What

Correct a small config paramaters. Have to use `validators-dir`

## Refs

- (this project accepts pull requests related to open issues)
- (if suggesting a new feature or change, please discuss it in an issue first)
- (if fixing a bug, there should be an issue describing it with steps to reproduce)
- (only fixing a minor bug - broken link, typo - an issue is not needed)
- (please link to the issue here)