### PR TITLE
CI overhaul - handle manual deployments to production

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Automatic Deployment to Dev/Staging
 
 # Run on pushes to main or PRs
 on:
@@ -9,10 +9,6 @@ on:
     branches:
       - main
       - dev
-      - release
-  # Launches build when release is published
-  release:
-    types: [published]
 
   # PRs created by external parties
   pull_request_target:
@@ -60,21 +56,11 @@ jobs:
           pip install awscli --upgrade --user
 
       - name: Build App
-        if: github.ref != 'refs/heads/release'
         env:
           ALGOLIA_ID: ${{ secrets.ALGOLIA_ID }}
           ALGOLIA_INDEX: ${{ secrets.ALGOLIA_INDEX }}
           ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
           GOOGLE_ANALYTICS_ID: ${{ secrets.STAGING_GOOGLE_ANALYTICS_ID }}
-        run: yarn build
-
-      - name: Build Release App
-        if: github.ref == 'refs/heads/release'
-        env:
-          ALGOLIA_ID: ${{ secrets.ALGOLIA_ID }}
-          ALGOLIA_INDEX: ${{ secrets.ALGOLIA_INDEX }}
-          ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
-          GOOGLE_ANALYTICS_ID: ${{ secrets.PROD_GOOGLE_ANALYTICS_ID }}
         run: yarn build
 
       - name: Configure AWS Development credentials
@@ -84,14 +70,6 @@ jobs:
           aws-access-key-id: ${{ secrets.DEV_AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.DEV_AWS_SECRET_ACCESS_KEY }}
           aws-region: ${{ secrets.DEV_AWS_DEFAULT_REGION }}
-
-      - name: Configure AWS Production credentials
-        uses: aws-actions/configure-aws-credentials@v1
-        if: ( github.ref == 'refs/heads/release' )
-        with:
-          aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
-          aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
-          aws-region: ${{ secrets.PROD_AWS_DEFAULT_REGION }}
 
       # Script to deploy to development environment
       - name: 'Deploy to S3: Development'
@@ -106,11 +84,3 @@ jobs:
         run: |
           aws s3 sync build/ s3://${{ secrets.DEV_BUCKET_NAME }}/staging --exclude "*.html" --cache-control max-age=0,no-cache,no-store,public
           aws s3 sync build/ s3://${{ secrets.DEV_BUCKET_NAME }}/staging --exclude "*" --include "*.html" --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
-
-      # Script to deploy to release environment
-      - name: 'Deploy to S3: Release'
-        if: github.ref == 'refs/heads/release'
-        run: |
-          aws s3 sync build/ s3://${{ secrets.RELEASE_BUCKET_NAME }} --delete --exclude "*.html" --exclude "sitemap.xml" --cache-control max-age=86400,public
-          aws s3 sync build/ s3://${{ secrets.RELEASE_BUCKET_NAME }} --delete --exclude "*" --include "*.html" --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
-          aws s3 sync build/ s3://${{ secrets.RELEASE_BUCKET_NAME }} --delete --exclude "*" --include "sitemap.xml" --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/xml

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -1,0 +1,73 @@
+name: Manual Deployment to Production
+
+on:
+    workflow_dispatch:
+      inputs:
+        tag:
+          description: Tagged version to deploy
+          required: true
+          type: string
+
+jobs:
+    deploy:
+        name: Deployment
+        runs-on: ubuntu-latest
+
+        steps:
+            - name: Cancel Previous Runs
+              uses: styfle/cancel-workflow-action@0.8.0
+              with:
+                access_token: ${{ github.token }}
+
+            - name: Remove broken apt repos [Ubuntu]
+              if: ${{ matrix.os }} == 'ubuntu-latest'
+              run: |
+                for apt_file in `grep -lr microsoft /etc/apt/sources.list.d/`; do sudo rm $apt_file; done
+
+            - uses: actions/checkout@v2
+              with:
+                fetch-depth: 0
+            
+            - name: Tag checkout
+              run:
+                git checkout ${{ github.event.inputs.tag }}
+
+            - uses: actions/cache@v2
+              with:
+                path: '**/node_modules'
+                key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}
+
+            - name: Setup Node.js
+              uses: actions/setup-node@v2
+              with:
+                node-version: 18.14.0
+
+            - name: Install
+              run: |
+                rm -rf .cache
+                rm -rf build
+                yarn config set cache-folder .yarn
+                yarn install
+                pip install awscli --upgrade --user
+
+            - name: Build App for release
+              env:
+                ALGOLIA_ID: ${{ secrets.ALGOLIA_ID }}
+                ALGOLIA_INDEX: ${{ secrets.ALGOLIA_INDEX }}
+                ALGOLIA_KEY: ${{ secrets.ALGOLIA_KEY }}
+                GOOGLE_ANALYTICS_ID: ${{ secrets.PROD_GOOGLE_ANALYTICS_ID }}
+              run: yarn build
+
+            - name: Configure AWS Production credentials
+              uses: aws-actions/configure-aws-credentials@v1
+              with:
+                aws-access-key-id: ${{ secrets.PROD_AWS_ACCESS_KEY_ID }}
+                aws-secret-access-key: ${{ secrets.PROD_AWS_SECRET_ACCESS_KEY }}
+                aws-region: ${{ secrets.PROD_AWS_DEFAULT_REGION }}
+
+            # Script to deploy to release environment
+            - name: 'Deploy to S3: Release'
+              run: |
+                aws s3 sync build/ s3://${{ secrets.RELEASE_BUCKET_NAME }} --delete --exclude "*.html" --exclude "sitemap.xml" --cache-control max-age=86400,public
+                aws s3 sync build/ s3://${{ secrets.RELEASE_BUCKET_NAME }} --delete --exclude "*" --include "*.html" --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/html
+                aws s3 sync build/ s3://${{ secrets.RELEASE_BUCKET_NAME }} --delete --exclude "*" --include "sitemap.xml" --cache-control max-age=0,no-cache,no-store,must-revalidate --content-type text/xml

--- a/.github/workflows/tag_release.yml
+++ b/.github/workflows/tag_release.yml
@@ -1,0 +1,48 @@
+name: Create Github Release
+
+on:
+  push:
+    tags:
+      - '[0-9]+.[0-9]+.[0-9]+'
+
+jobs:
+  release:
+    name: Github Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Cancel Previous Runs
+        uses: styfle/cancel-workflow-action@0.8.0
+        with:
+          access_token: ${{ github.token }}
+
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - name: Create Github Release
+        uses: actions/github-script@v6
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            if (!${{ github.ref_name }}) {
+              core.setFailed("RELEASE_TAG is not defined.")
+
+              return;
+            }
+            try {
+              const response = await github.rest.repos.createRelease({
+                name: ${{ github.ref_name }},
+                tag_name: ${{ github.ref_name }},
+                draft: false,
+                generate_release_notes: true,
+                owner: context.repo.owner,
+                prerelease: false,
+                repo: context.repo.repo,
+              });
+
+              core.exportVariable('RELEASE_ID', response.data.id);
+              core.exportVariable('RELEASE_UPLOAD_URL', response.data.upload_url);
+            } catch (error) {
+              core.setFailed(error.message);
+            }


### PR DESCRIPTION
In this PR we propose a change in the way the CI handles the deployments.

- Any commits to dev/main branches will trigger **dev_deploy.yml** which will build and deploy the website to the dev/staging environment.
- Any tagged commits will trigger **tag_release.yml** which will craft the Github Release on releases page
- Deployments to production are handled through a manual action which requires a valid tagged version as input.