### PR TITLE
Fix gas limit

### DIFF
--- a/docs/about/specs/README.md
+++ b/docs/about/specs/README.md
@@ -9,7 +9,7 @@ keywords: [gnosis specs, gnosis specifications, gnosis block size, block speed, 
 
 | Property |  |
 | - | - |
-| Block Size | 30M gas units |
+| Block Size | 17M gas units |
 | Block Speed | 5 seconds |
 | Gas price | check [gas price oracle](/tools/oracles/gas-price) |
 | Patchset | London |


### PR DESCRIPTION
## What

- State that the block gas limit is 17M gas.

The gas limit advertised in Chain Specifications does not reflect the limit currently on the network, see https://gnosis.blockscout.com/block/34038420. I am aware that the validators can collectively decide to change it. LMK if I am missing something