### PR TITLE
Update README.md

### DIFF
--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -166,7 +166,7 @@ Validators are advised to consider those numbers when planning their infrastruct
 The easiest option for running a node with your own hardware is using plug-and-play boxes. Preconfigured machines from vendors offer the most straightforward experience: order, connect, run. Everything is preconfigured and runs automatically with an intuitive guide and dashboard for monitoring and controlling the software.
 
 - [DappNode](https://docs.gnosischain.com/node/tools/dappnode/)
-- [Avado](https://docs.ava.do/packages/gnosis/)
+- [Avado]([https://docs.ava.do/packages/gnosis/](https://docs.ava.do/more-staking-opportunities/gnosis-staking))
 - [Stereum](https://stereum.net/)
 
 ## Spinning up the node


### PR DESCRIPTION
Changed the URL for the AVADO documentation.
The correct URL is https://docs.ava.do/more-staking-opportunities/gnosis-staking

## What

- (describe the changes in detail)

## Refs

- (this project accepts pull requests related to open issues)
- (if suggesting a new feature or change, please discuss it in an issue first)
- (if fixing a bug, there should be an issue describing it with steps to reproduce)
- (only fixing a minor bug - broken link, typo - an issue is not needed)
- (please link to the issue here)