### PR TITLE
docs: update mGNO documentation

### DIFF
--- a/docs/about/tokens/gno.md
+++ b/docs/about/tokens/gno.md
@@ -90,10 +90,11 @@ Check out [Chiado Testnet specs](/concepts/networks/chiado#gno-token) for more i
 
 By staking your GNO tokens, you play a vital role in securing the Gnosis chain through the validation of blocks within the PoS consensus. As a reward for your participation, you will receive staking [rewards](../../node/rewards-penalties). For a more comprehensive understanding of the validator deposit process, check the [validator deposit process](/node/manual/validator/deposit) page.
 
-In order to establish a highly precise ETH-mirrored environment, it is required to stake a minimum of 32 tokens on the Gnosis Beacon Chain. To facilitate this, the mGNO token serves as a meta-token spe
-cifically designed for staking purposes. During the deposit process, an automatic conversion takes place where 1 GNO is transformed into 32 mGNO tokens behind the scenes.
+:::note Historical use of `mGNO`
 
-The mGNO contract address on the Gnosis network is as follows: [0x722fc4DAABFEaff81b97894fC623f91814a1BF68](https://gnosisscan.io/address/0x722fc4DAABFEaff81b97894fC623f91814a1BF68).
+Historically, deposits on the Beacon Chain were made with a token called `mGNO` ([0x722fc4DAABFEaff81b97894fC623f91814a1BF68](https://gnosisscan.io/address/0x722fc4DAABFEaff81b97894fC623f91814a1BF68)), with a conversion rate of `1 GNO = 32 mGNO`. This was done to mimic Ethereum's `32 ETH` staking requirement, but is now deprecated and no longer serves any purpose.
+
+:::
 
 For those who prefer not to manage the infrastructure themselves, liquid staking providers offer the opportunity to stake without the need for personal infrastructure management. For more in-depth information about sGNO and rGNO tokens, please consult the [Stakewise](/tools/beacon-chain/liquid-staking#tokens-sgno--rgno) page.
 


### PR DESCRIPTION
## What

`mGNO` no longer serves any purpose. I'd remove it from the docs altogether, but it might still be useful to a tiny fraction of users. We can revisit the removal of any mention at some point.