### PR TITLE
Update _generate_validator_keys_wagyu.md

### DIFF
--- a/docs/node/manual/validator/_partials/_generate_validator_keys_wagyu.md
+++ b/docs/node/manual/validator/_partials/_generate_validator_keys_wagyu.md
@@ -24,6 +24,10 @@
 
   ![DAppNode Step 3j](/img/node/dappnode-step3j.png)
 
+:::caution Be sure to enter a withdrawal address at this step. This address will be used to receive partial or full withdrawals. You can also choose not to enter an address at this step, but be aware that updating it later can be difficult. [Withdrawals](../node/management/withdrawals.md)
+
+Please note that once you have chosen a withdrawal address (either at this step or later), it will not be possible to update it to another address. Therefore, make sure to choose an address that you control and that is secure. :::
+
   :::info 
   If you are running this program to generate keys within the context of the DAppNode Gnosis Chain Hardware Validator Incentive Program, make sure to generate 4 validators and to fill in the ETH1 Withdrawal Address Field with an address you have full control over.  Also make sure to choose a directory that reflects the folder where you want the files to be saved.
   :::


### PR DESCRIPTION
## What

Adding a warning about entering a withdrawal address at the key generation step in Wagyu. This idea comes after seeing multiple validators not paying attention to it recently and ending up having to update their withdrawal credential using Ethdo after which is  not really easy for non technical people. This warning should hopefully prevent such cases in the future.