### PR TITLE
fix: correctly render jwt generation instruction from partials import

### DIFF
--- a/docs/node/manual/configure-server.md
+++ b/docs/node/manual/configure-server.md
@@ -37,10 +37,10 @@ Some users recommend using [Chrony](https://chrony.tuxfamily.org/) as a [method 
 :::
 
 ### Create JWT
-<!-- Create a fix for rendering  -->
-<!-- import JwtGenerationPartial from '@site/docs/node/manual/server/_partials/_jwt-generation-partial.mdx';
 
-<JwtGenerationPartial /> -->
+import JwtGenerationPartial from '@site/docs/node/manual/server/_partials/_jwt-generation-partial.md';
+
+<JwtGenerationPartial />
 
 ## Set up Networking
 


### PR DESCRIPTION
## What
This PR fixes the rendering error in the generating JWT section of [the configure step](https://docs.gnosischain.com/node/manual/configure-server#create-jwt) in the documentation.

Changes:

From
![image](https://github.com/user-attachments/assets/21edb47a-0cea-4b99-a2f3-278027167b21)

to

![image](https://github.com/user-attachments/assets/42092efe-68fe-4d92-ae15-b6d46f09810f)



## Refs

- (this project accepts pull requests related to open issues)
- (if suggesting a new feature or change, please discuss it in an issue first)
- (if fixing a bug, there should be an issue describing it with steps to reproduce)
- (only fixing a minor bug - broken link, typo - an issue is not needed)
- (please link to the issue here)