### PR TITLE
fix: update 404 link `node/README.md`

### DIFF
--- a/docs/node/README.md
+++ b/docs/node/README.md
@@ -283,7 +283,7 @@ Please keep in mind that this is just a basic example, all other settings will b
 
 **Running Nethermind**
 
-Nethermind offers various [installation options](https://docs.nethermind.io/nethermind/first-steps-with-nethermind/getting-started). The package comes with various binaries, including a Launcher with a guided setup, which will help you to create the configuration interactively. Alternatively, you find Runner which is the executable itself and you can just run it with config flags. JSON RPC is enabled by default.
+Nethermind offers various [installation options](https://docs.nethermind.io/get-started/installing-nethermind). The package comes with various binaries, including a Launcher with a guided setup, which will help you to create the configuration interactively. Alternatively, you find Runner which is the executable itself and you can just run it with config flags. JSON RPC is enabled by default.
 
 ```
 nethermind --config gnosis \


### PR DESCRIPTION
## Description
Hi! I fixes a broken link in the `node/README.md` file. The old link pointed to a deprecated or non-existent page for the Nethermind documentation. It has been updated to the correct and current URL.