### PR TITLE
docs: fix typo in doc about BSC - Gnosis Chain bridge

### DIFF
--- a/docs/faq/bridges.md
+++ b/docs/faq/bridges.md
@@ -2,7 +2,7 @@
 
 1. Can I bridge tokens between Gnosis Chain and BSC using Omni Bridge
 
-   The BSC - Gnosis Chain bridge has been depreciated you can instead use a third party bridge like Jumper for example.
+   The BSC - Gnosis Chain bridge has been deprecated you can instead use a third party bridge like Jumper for example.
 
 2. What is the best way to bridge it to another chain?
 


### PR DESCRIPTION
## What

I’ve corrected a typo in the documentation. The word "depreciated" was used incorrectly and has been replaced with the correct term "deprecated" in the sentence:  
"The BSC - Gnosis Chain bridge has been **deprecated**. You can instead use a third-party bridge like Jumper for example."