### PR TITLE
docs: Fix typo in "infrastructure" in description

### DIFF
--- a/docs/about/networks/mainnet.md
+++ b/docs/about/networks/mainnet.md
@@ -1,5 +1,5 @@
 ---
-description: Gnosis mainnet infrstructure details.
+description: Gnosis mainnet infrastructure details.
 keywords:
   [gnosis mainnet, mainnet, gnosis infrastructure, gnosis faucet, gno, xdai]
 ---


### PR DESCRIPTION
## What

Noticed a typo in the description: "infrstructure" → "infrastructure".
Fixed it to ensure clarity and correctness.ink, typo - an issue is not needed)