### PR TITLE
ci: bump actions/cache to v4

### DIFF
--- a/.github/workflows/dev_deploy.yml
+++ b/.github/workflows/dev_deploy.yml
@@ -34,7 +34,7 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}

--- a/.github/workflows/prod_deploy.yml
+++ b/.github/workflows/prod_deploy.yml
@@ -31,7 +31,7 @@ jobs:
           git fetch --prune --unshallow --tags
           git checkout ${{ github.event.inputs.tag }}
 
-      - uses: actions/cache@v3
+      - uses: actions/cache@v4
         with:
           path: '**/node_modules'
           key: ${{ runner.os }}-modules-${{ hashFiles('**/yarn.lock') }}


### PR DESCRIPTION
Updates cache action to v4 for future-proofing. Workflows behave the same.