### PR TITLE
fix dead link 12-08-temporary-bootnodes.md

### DIFF
--- a/updates/2022/12-08-temporary-bootnodes.md
+++ b/updates/2022/12-08-temporary-bootnodes.md
@@ -106,7 +106,7 @@ lighthouse
 
 ### Lodestar
 
-Lodestar utilizes multiple [`--bootnodes`](https://chainsafe.github.io/lodestar/beacon-management/beacon-cli/#-bootnodes) flags to specify custom bootnodes. 
+Lodestar utilizes multiple [`--bootnodes`](https://chainsafe.github.io/lodestar/run/beacon-management/beacon-cli/#--bootnodes) flags to specify custom bootnodes. 
 
 Docs: https://chainsafe.github.io/lodestar/beacon-management/networking/#peer-discovery-discv5
 


### PR DESCRIPTION
Hey team—noticed a dead link, replaced it with a working URL

https://chainsafe.github.io/lodestar/beacon-management/beacon-cli/#-bootnodes - old
https://chainsafe.github.io/lodestar/run/beacon-management/beacon-cli/#--bootnodes - new