### PR TITLE
update ethstaker org github handle

### DIFF
--- a/docs/node/Node Tools/eth-docker.md
+++ b/docs/node/Node Tools/eth-docker.md
@@ -13,7 +13,7 @@ Eth-docker allows user to set up Gnosis clients by answering simple dialog-based
 
 ## References
 1. Eth-docker Docs: https://eth-docker.net/
-2. Github: https://github.com/eth-educators/eth-docker
+2. Github: https://github.com/ethstaker/eth-docker
 
 
 ## Prerequisite
@@ -30,7 +30,7 @@ Open a new terminal, copy and paste the command below.
 Download eth-docker
 
 ```bash
-cd ~ && git clone https://github.com/eth-educators/eth-docker.git && cd eth-docker
+cd ~ && git clone https://github.com/ethstaker/eth-docker.git && cd eth-docker
 ```
 
 Install pre-requisites such as Docker

--- a/docs/node/management/monitoring-node.md
+++ b/docs/node/management/monitoring-node.md
@@ -14,7 +14,7 @@ To monitor the network, options include ethstats, forkmon, beacon.gnosischain, a
 
 ![Prometheus-Grafana-NodeExporter](../../../static/img/node/prometheus-grafana.png)
 
-To set up these tools, please refer to the excellent guide from ethstaker on [how to do monitoring for an Ethereum validator](https://github.com/eth-educators/ethstaker-guides/blob/main/monitoring.md).
+To set up these tools, please refer to the excellent guide from ethstaker on [how to do monitoring for an Ethereum validator](https://github.com/ethstaker/ethstaker-guides/blob/main/monitoring.md).
 
 You may also refer to the [Ethereum Setup Instructions ](https://launchpad.ethereum.org/en/)and [CoinCashew's guide](https://www.coincashew.com/coins/overview-eth/guide-or-how-to-setup-a-validator-on-eth2-mainnet/part-i-installation/monitoring-your-validator-with-grafana-and-prometheus) for best monitoring practices.
 

--- a/docs/node/manual/validator/_partials/_generate_validator_keys_cli.md
+++ b/docs/node/manual/validator/_partials/_generate_validator_keys_cli.md
@@ -17,7 +17,7 @@ Learn more about [keys](https://kb.beaconcha.in/ethereum-2-keys) and [withdrawal
 ]}>
 <TabItem value="others">
 
-- Copy the download link for Linux, MacOS or Arm64 package from the [ETHstaker Deposit CLI](https://github.com/eth-educators/ethstaker-deposit-cli/releases).
+- Copy the download link for Linux, MacOS or Arm64 package from the [ETHstaker Deposit CLI](https://github.com/ethstaker/ethstaker-deposit-cli/releases).
 
 - Download the Validator Data Generation tool
     ```shell
@@ -52,7 +52,7 @@ Learn more about [keys](https://kb.beaconcha.in/ethereum-2-keys) and [withdrawal
 </TabItem>
 <TabItem value="win">
 
-- Download the Windows version of the [ETHstaker Deposit CLI](https://github.com/eth-educators/ethstaker-deposit-cli/releases) from the releases page.
+- Download the Windows version of the [ETHstaker Deposit CLI](https://github.com/ethstaker/ethstaker-deposit-cli/releases) from the releases page.
 - Execute Validator Data Generation tool and follow the instructions.
     In case of doubts, check the [tool documentation](https://deposit-cli.ethstaker.cc/landing.html)
 


### PR DESCRIPTION
the ethstaker org github handle was updated from eth-educators to ethstaker because the handle was squatted for years and recently released to us

## What

updating URL to point to the correct org

## Refs

none