### PR TITLE
Update Cow github organization name in Deploy A Cow Swap Widget.md

### DIFF
--- a/docs/technicalguides/DeFi/Deploy A Cow Swap Widget.md
+++ b/docs/technicalguides/DeFi/Deploy A Cow Swap Widget.md
@@ -9,7 +9,7 @@ This tutorial will guide you through deploying Cow Swap swap frontends using the
 First, clone the `@widget-examples` repository to your local machine. This repository contains all the necessary code examples for deploying Cow Swap swap frontends.
     
     ```bash
-git clone https://github.com/cowswap/widget-examples.git
+git clone https://github.com/cowprotocol/widget-examples.git
 cd widget-examples
 ```
 


### PR DESCRIPTION
## What

- update old `cowswap` github organization name to new `cowprotocol` in link.

## Refs

very minor, no need for an issue