### PR TITLE
docs(rpc-providers): reference OpenChainBench for live Gnosis RPC latency

### DIFF
--- a/docs/tools/RPC Providers/README.md
+++ b/docs/tools/RPC Providers/README.md
@@ -16,6 +16,7 @@ RPC Providers implement the JSON RPC API that Dapps and developers can interact 
 - [JSON RPC API reference](https://ethereum.org/en/developers/docs/apis/json-rpc/)
 - [JSON RPC Postman](https://documenter.getpostman.com/view/4117254/ethereum-json-rpc/RVu7CT5J?version=latest)
 - [Start developing in Gnosis](/developers/overview)
+- [OpenChainBench Gnosis RPC benchmark](https://openchainbench.com/benchmarks/gnosis-rpc): live latency comparison of the public no-key Gnosis endpoints, probed from three regions every minute.
 
 
 ## Gnosis


### PR DESCRIPTION
## Summary

Adds one bullet to the intro list of `docs/tools/RPC Providers/README.md` pointing at the [OpenChainBench Gnosis RPC benchmark](https://openchainbench.com/benchmarks/gnosis-rpc) so developers picking an endpoint have a live third-party latency comparison alongside the existing JSON-RPC references.

## Why

The page currently intros with a short reference list (JSON RPC API, Postman, Start developing in Gnosis). OpenChainBench probes the public Gnosis endpoints from three regions every minute and publishes p50, p95 and p99 latency under an open methodology, CC BY 4.0 data license.

- Live Gnosis benchmark: https://openchainbench.com/benchmarks/gnosis-rpc
- Methodology: https://openchainbench.com/methodology
- No affiliation with GnosisDAO or the Gnosis Chain team

Happy to reword or move if this does not fit the docs' tone.

## Test plan

- [x] Single-line addition in an existing bullet list
- [x] External link tested and returns 200