### PR TITLE
Promote bridge docs + faucet URL updates from dev

### DIFF
--- a/docs/about/networks/chiado.md
+++ b/docs/about/networks/chiado.md
@@ -64,7 +64,7 @@ Image: Trams in Lisbon (credit: [Lisa Fotios](https://www.pexels.com/photo/peopl
 | Beacon Checkpoint Sync        | https://checkpoint.chiadochain.net    |
 | Fork monitor                  | https://forkmon.chiadochain.net       |
 | EthStats                      | https://ethstats.chiadochain.net      |
-| Faucet                        | https://faucet.chiadochain.net/       |
+| Faucet                        | https://faucet.gnosischain.com/?chain=chiado       |
 
 ### Key Parameters
 

--- a/docs/bridges/fast-confirmation-rule.md
+++ b/docs/bridges/fast-confirmation-rule.md
@@ -1,0 +1,49 @@
+---
+sidebar_position: 9
+title: Fast Confirmation Rule integration
+keywords: [gnosis bridge, bridge architecture]
+---
+
+# What is FCR?
+
+The Fast Confirmation Rule (FCR) is a new Ethereum feature that provides a very strong assurance a block will not be reorged within 1 slot(13 seconds), a 98% reduction from the approximately 13-minute time to finality.
+
+FCR works by counting attestations in real-time. If there is overwhelming support for a block and robustness checks are passed, the block is fast-confirmed.
+
+FCR comes with two core assumptions. First, it assumes the network is synchronous, meaning attestations are delivered within about 8 seconds. Second, it assumes there is no adversary with more than 25% stake, slightly less than the 33% maximum adversarial stake that finality can withstand. If these assumptions hold, any fast-confirmed block will, with certainty, be finalized.
+These assumptions are reasonable and usually hold. In the rare case that they do not, it can cause either a liveness or a safety failure. A liveness failure means it may take longer than 13 seconds to fast-confirm a block. Eventually, the rule automatically falls back to finality. This is a feature, not a bug: FCR falls back to a more secure confirmation rule when needed. A safety failure means that a fast-confirmed block is reorged. With FCR, reorg risk is extremely small. ethPandaOps has conducted experiment by replaying historical Ethereum beacon chain data(a year) through FCR from consensus clients, the result shows that there is [zero false confirmation](https://ethpandaops.io/posts/fcr-simulator/).
+
+# Why Gnosis bridges integrate FCR?
+
+By integrating FCR, it can drastically decrease the current bridging time from Ethereum.
+
+# How would it work in Gnosis bridges?
+
+By default, the processing rules are the following:
+
+| Source Chain | Destination Chain | Processing rule          |
+| ------------ | ----------------- | ------------------------ |
+| Ethereum     | Gnosis Chain      | FCR (~12s)               |
+| Gnosis Chain | Ethereum          | Block finality (~5 mins) |
+
+1. Bridges smart contracts: No modification.
+2. Bridge validators logic:
+   1. Based on the bridging directions, process the bridging tx accordingly.
+
+   2. The bridge validators run their own nodes, which ensure that the network synchrony of the FCR assumption is satisfied. We require bridge validator to run different clients to ensure client diversity.
+
+   3. In case of hardfork or instability of the network, bridge validator will default to block finality. An alert is raised when a FCR-confirmed processed tx is not later included in the finalized block.
+
+3. Monitoring: Monitoring system will be built to track the following metrics:
+   1. Fast confirmed block by each clients
+   2. Reorgs event
+
+# Q&A
+
+1. Can user choose FCR or block finality when they initiate the bridging?
+
+No, by default, all bridging txs from Ethereum use FCR, while all bridging txs from Gnosis Chain use block finality. Except in the case where network is unstable or during hardfork period, block finality is the default.
+
+# Reference
+
+1. https://fastconfirm.it/

--- a/docs/bridges/management/decisions.md
+++ b/docs/bridges/management/decisions.md
@@ -8,6 +8,38 @@ keywords: [governance board, bridge governance]
 
 The [Bridge Governance Board](./#current-bridge-governors) is responsible for enacting updates related to bridge functionality, contract upgrades, and other parameters impacting bridge operations. The following items have been implemented by the board.
 
+## Rotating bridge validator addresses in batch(1/2)
+🗳 Justification:
+
+1. As a security hardening process, we're replacing the bridge validator addresses on AMB and xDAI bridge validator contract.    
+   1. Gnosis:    
+        1. Old address for AMB: 0xbdc141c8d2343f33f40cb9edd601ccf460cd0dde    
+        2. New address for AMB: 0x4A07b8AE561CC558eDD3f1836365AB8e02C52dE2    
+        3. Old address for xDAI bridge: 0x97630e2ae609d4104abda91f3066c556403182dd    
+        4. New address for xDAI bridge: 0x82b00cA9D162859f645B51967746E55bb6498DfC    
+   2. Protofire:    
+        1. Old address for AMB: 0x459a3bd49f1ff109bc90b76125533699aaaaf9a6    
+        2. New address for AMB: 0xAD93BffBC65002cC75AD2d5770d3AAfFdefd8D55    
+        3. Old address for xDAI bridge: 0x4d1c96b9a49c4469a0b720a22b74b034eddfe051    
+        4. New address for xDAI bridge: 0x2245bFAD58a6cD50e9e413084d4091C497281911    
+   3. Giveth:    
+        1. Old address for AMB: 0x105cd22ed3d089bf5589c59b452f9de0796ca52d    
+        2. New address for AMB: 0xE9fc29AE64c2923FeBb615cB016b77aF9492EBcE    
+        3. Old address for xDAI bridge: 0xc073c8e5ed9aa11cf6776c69b3e13b259ba9f506    
+        4. New address for xDAI bridge: 0xC9f0d7e76E7970590e217c57Af5d2B7d07A62c13    
+   4. Kleros:    
+        1. Old address for AMB: 0x7117f73afbdec3221bdd50ddcbf73204b3998302    
+        2. New address for AMB: 0x156c0DAAb0cD73c224a424a781866d35f0F8Fade    
+        3. Old address for xDAI bridge: 0x7117f73afbdec3221bdd50ddcbf73204b3998302    
+        4. New address for xDAI bridge: 0x156c0DAAb0cD73c224a424a781866d35f0F8Fade    
+
+Tx on Ethereum: [url](https://app.safe.global/transactions/tx?safe=eth:0x42F38ec5A75acCEc50054671233dfAC9C0E7A3F6&id=multisig_0x42F38ec5A75acCEc50054671233dfAC9C0E7A3F6_0x32c52cf71d61d8134b5bdbc7e96dd2ed8cbe618a2fbd8d4bcaab91e3595bbf17
+)
+
+Tx on GC: [url](https://app.safe.global/transactions/tx?safe=gno:0x7a48Dac683DA91e4faa5aB13D91AB5fd170875bd&id=multisig_0x7a48Dac683DA91e4faa5aB13D91AB5fd170875bd_0x71e27be50fc8a0140f8b5908493dbf4f923c99a5889aa71c455fff334118778d
+) 
+
+✅ Implemented: Jul 21, 2026.
 ## Rotating Hopr bridge validator address
 
 🗳 Justification:

--- a/docs/bridges/management/validators.md
+++ b/docs/bridges/management/validators.md
@@ -21,10 +21,10 @@ Due to the fact that Omnibridge is built on top of AMB, these two bridges share 
 
 | GC Address                                                                                                                  | Organization Name |
 | --------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| [gno:0x459a3bd49f1ff109bc90b76125533699aaaaf9a6](https://gnosisscan.io/address/0x459a3bd49f1ff109bc90b76125533699aaaaf9a6)  | Protofire         |
-| [gno:0x105CD22eD3D089Bf5589C59b452f9dE0796Ca52d](https://gnosisscan.io/address/0x105CD22eD3D089Bf5589C59b452f9dE0796Ca52d)  | Giveth            |
-| [gno:0x7117F73aFBDec3221bDD50DdCbf73204b3998302 ](https://gnosisscan.io/address/0x7117F73aFBDec3221bDD50DdCbf73204b3998302) | Kleros            |
-| [gno:0xbdc141c8d2343f33f40cb9edd601ccf460cd0dde](https://gnosisscan.io/address/0xbdc141c8d2343f33f40cb9edd601ccf460cd0dde)  | GnosisDAO         |
+| [gno:0xAD93BffBC65002cC75AD2d5770d3AAfFdefd8D55](https://gnosisscan.io/address/0xAD93BffBC65002cC75AD2d5770d3AAfFdefd8D55)  | Protofire         |
+| [gno:0xE9fc29AE64c2923FeBb615cB016b77aF9492EBcE](https://gnosisscan.io/address/0xE9fc29AE64c2923FeBb615cB016b77aF9492EBcE)  | Giveth            |
+| [gno:0x156c0DAAb0cD73c224a424a781866d35f0F8Fade ](https://gnosisscan.io/address/0x156c0DAAb0cD73c224a424a781866d35f0F8Fade) | Kleros            |
+| [gno:0x4A07b8AE561CC558eDD3f1836365AB8e02C52dE2](https://gnosisscan.io/address/0x4A07b8AE561CC558eDD3f1836365AB8e02C52dE2)  | GnosisDAO         |
 | [gno:0xCC46a3873BfCaa08a6a946a308bB621535D6E6Dd](https://gnosisscan.io/address/0xCC46a3873BfCaa08a6a946a308bB621535D6E6Dd)  | Cow Protocol      |
 | [gno:0x258667E543C913264388B33328337257aF208a8f](https://gnosisscan.io/address/0x258667E543C913264388B33328337257aF208a8f)  | Gnosis Safe       |
 | [gno:0x6236925ff8aa09f29f1609a9bcd54af20e4be6b4](https://gnosisscan.io/address/0x6236925ff8aa09f29f1609a9bcd54af20e4be6b4)  | Hopr              |
@@ -56,12 +56,12 @@ Bridge transactions currently requires signatures from 4 of 7 validators.
 
 | Organization | Gnosis Address                                                                                                                      |
 | ------------ | ----------------------------------------------------------------------------------------------------------------------------------- |
-| GnosisDao    | [gno:0x97630e2ae609d4104abda91f3066c556403182dd](https://gnosis.blockscout.com/address/0x97630e2ae609d4104abda91f3066c556403182dd)  |
-| Protofire    | [gno:0x4d1c96b9a49c4469a0b720a22b74b034eddfe051](https://gnosis.blockscout.com/address/0x4D1c96B9A49C4469A0b720a22b74b034EDdFe051)  |
+| GnosisDao    | [gno:0x82b00cA9D162859f645B51967746E55bb6498DfC](https://gnosis.blockscout.com/address/0x82b00cA9D162859f645B51967746E55bb6498DfC)  |
+| Protofire    | [gno:0x2245bFAD58a6cD50e9e413084d4091C497281911](https://gnosis.blockscout.com/address/0x2245bFAD58a6cD50e9e413084d4091C497281911)  |
 | CowProtocol  | [gno:0xAeE7C90Ef0fC461ec63c4d451B12c340642bc656](https://gnosis.blockscout.com/address/0xAeE7C90Ef0fC461ec63c4d451B12c340642bc656)  |
-| Giveth       | [gno:0xc073C8E5ED9Aa11CF6776C69b3e13b259Ba9F506](https://gnosis.blockscout.com/address/0xc073C8E5ED9Aa11CF6776C69b3e13b259Ba9F506)  |
+| Giveth       | [gno:0xC9f0d7e76E7970590e217c57Af5d2B7d07A62c13](https://gnosis.blockscout.com/address/0xC9f0d7e76E7970590e217c57Af5d2B7d07A62c13)  |
 | GnosisSafe   | [gno:0x1312e98995bbcc30fc63db3cef807e20cdd33dca](https://gnosis.blockscout.com/address/0x1312e98995bbcc30fc63db3cef807e20cdd33dca)  |
-| Kleros       | [gno:0x7117F73aFBDec3221bDD50DdCbf73204b3998302 ](https://gnosis.blockscout.com/address/0x7117F73aFBDec3221bDD50DdCbf73204b3998302) |
+| Kleros       | [gno:0x156c0DAAb0cD73c224a424a781866d35f0F8Fade ](https://gnosis.blockscout.com/address/0x156c0DAAb0cD73c224a424a781866d35f0F8Fade) |
 | Hopr         | [gno:0x6236925ff8aa09f29f1609a9bcd54af20e4be6b4](https://gnosis.blockscout.com/address/0x6236925ff8aa09f29f1609a9bcd54af20e4be6b4)  |
 
 </TabItem>

--- a/docs/bridges/roadmap.md
+++ b/docs/bridges/roadmap.md
@@ -5,13 +5,17 @@ description: Gnosis is investing significant resources into trust-minimization o
 keywords: [bridge roadmap, trustless bridge, light client, zksnark]
 ---
 
+### Fast Confirmation Rule(FCR) integration
+
+Fast Confirmation Rule is a new Ethereum feature that provides a very strong assurance a block will not be reorged within 1 slot(13 seconds), a 98% reduction from the approximately 13-minute time to finality. Integrating FCR into bridges improves the bridging time down to seconds without sacrificing the security. Check [here](./fast-confirmation-rule.md) for more details.
+
+### Hashi - A cross chain protocol based on distributed trust of the underlying security mechanisms ✅
+
 :::warning
 🚨 The Hashi integration initiative — originally approved under [GIP‑93](https://forum.gnosis.io/t/gip-93-should-gnosisdao-support-the-integration-of-hashi-within-gnosis-chains-canonical-bridges/8245) and subsequently implemented across both the AMB & xDAI bridges—is formally **deprecated**.
 
 Read the entire forum details [here](https://forum.gnosis.io/t/deprecation-notice-hashi-on-gnosis-canonical-bridges-ends-maintenance/11467)
 :::
-
-### Hashi - A cross chain protocol based on distributed trust of the underlying security mechanisms ✅
 
 Hashi, a cross chain protocol based on distributed trust of the underlying security mechanisms
 Hashi is an EVM Hash Oracle Aggregator designed to enhance cross-chain bridge security by aggregating block headers from various sources. By requiring validation from multiple independent mechanisms, Hashi ensures greater resilience against security incidents. It supports 15+ General Message Passing bridges and ZK light clients, promoting redundancy and reducing reliance on single mechanisms. Integrating Hashi into Gnosis Chain's bridges strengthens security, decentralization, and interoperability. This initiative aims to set a new standard for cross-chain transactions, enhancing user confidence and bolstering the Gnosis ecosystem's security posture. [Check out the proposal](https://forum.gnosis.io/t/gip-93-should-gnosisdao-support-the-integration-of-hashi-within-gnosis-chains-canonical-bridges/8245) .

--- a/docs/tools/Faucets.md
+++ b/docs/tools/Faucets.md
@@ -14,7 +14,7 @@ If the faucet is not functioning properly, feel free to seek assistance on the [
 ## Official Faucet
 
 - [Gnosis Chain Faucet](https://faucet.gnosischain.com/)
-- [Chiado Testnet Faucet](https://faucet.chiadochain.net/)
+- [Chiado Testnet Faucet](https://faucet.gnosischain.com/?chain=chiado)
 
 ## Community Faucets
 


### PR DESCRIPTION
Cherry-picks the dev-only doc content missing from main. Excludes package.json/yarn.lock (main is ahead via #849).