### PR TITLE
fix: replace expired domains in docs

### DIFF
--- a/docs/about/networks/README.md
+++ b/docs/about/networks/README.md
@@ -26,4 +26,4 @@ keywords:
 | CL Explorer        | https://beaconchain.gnosischain.com/           | https://beacon.chiadochain.net       |
 | Fork monitor       | https://forkmon.gnosischain.com  | https://forkmon.chiadochain.net      |
 | EthStats           | https://ethstats.gnosischain.com | https://ethstats.chiadochain.net     |
-| Faucet             | https://faucet.gnosischain.com/  | https://faucet.chiadochain.net/      |
+| Faucet             | https://faucet.gnosischain.com/  | https://faucet.gnosischain.com/?chain=chiado      |

--- a/docs/about/networks/chiado.md
+++ b/docs/about/networks/chiado.md
@@ -45,7 +45,7 @@ Image: Trams in Lisbon (credit: [Lisa Fotios](https://www.pexels.com/photo/peopl
 ### How to Participate
 
 - [Running a Chiado node](https://docs.sedge.nethermind.io/docs/networks/chiado) with [Nethermind Sedge](https://docs.sedge.nethermind.io/)
-- (Here by Dragons): If you can get your hands on Testnet GNO on Chiado, you will need to interact with the [deposit contract](https://blockscout.com/gnosis/chiado/address/0xc5be8bf53755a41c2385e7aa86f6a9e28746f466) programmatically, or deploy your own [Deposit UI](/node/manual/validator/deposit#depositing-for-chiado-testnet) with the updated config files
+- (Here by Dragons): If you can get your hands on Testnet GNO on Chiado, you will need to interact with the [deposit contract](https://blockscout.com/gnosis/chiado/address/0xc5be8bf53755a41c2385e7aa86f6a9e28746f466) programmatically, or follow the [Chiado deposit instructions](/node/manual/validator/deposit#depositing-for-chiado-testnet)
 
 ## Summary
 

--- a/docs/about/networks/mainnet.md
+++ b/docs/about/networks/mainnet.md
@@ -30,7 +30,7 @@ keywords:
 | Fork monitor             | https://forkmon.gnosischain.com             |
 | EthStats                 | https://ethstats.gnosischain.com            |
 | Forked Blocks            | https://gnosis.blockscout.com/reorgs        |
-| Faucet                   | https://gnosisfaucet.com                    |
+| Faucet                   | https://faucet.gnosischain.com/             |
 
 ### Consensus Layer
 

--- a/docs/developers/quickstart.md
+++ b/docs/developers/quickstart.md
@@ -36,8 +36,7 @@ After you create a wallet, add the Chiado network to the list of available netwo
 Lastly, top up the wallet with xDAI that you'll use for contract deployments on one of the environments: Chiado Testnet or Gnosis Mainnet. It's recommended to deploy contracts on the testnet first and use the mainnet only after you've done proper security audits.
 
 Testnets on any EVM-compatible chains don't require real funds to pay for transactions. Instead, they use faucets that represent free tokens. You can use the following faucets to get xDAI on the Chiado testnet:
-- [Chiado faucet](https://faucet.chiadochain.net/)
-- [Gnosis Chain Faucet](https://faucet.gnosischain.com/)
+- [Gnosis Chain Faucet (Chiado)](https://faucet.gnosischain.com/?chain=chiado)
 
 ![faucet](/img/developers/quickstart/faucet.png)
 

--- a/docs/faq/Node FAQs/depositWithdrawalReward.md
+++ b/docs/faq/Node FAQs/depositWithdrawalReward.md
@@ -39,7 +39,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 7. **Where can I check my withdrawal credential?**
 
-    You have to claim withdrawals manually now, you can do so on the [Deposit page](https://deposit.gnosischain.com/) or on the [Deposit contract](https://gnosisscan.io/address/0x0b98057ea310f4d31f2a452b414647007d1645d9#writeProxyContract#F4). You can also visit [official docs](https://docs.gnosischain.com/node/management/withdrawals#check-withdrawal-credential) for more detail.
+    You have to claim withdrawals manually now, you can do so on the [Deposit page](https://validators.gnosischain.com/) or on the [Deposit contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial). You can also visit [official docs](https://docs.gnosischain.com/node/management/withdrawals#check-withdrawal-credential) for more detail.
 
 8. **Do partial withdrawals happen automatically?**
 
@@ -88,7 +88,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 18. **When you receive rewards from validation, where does the reward go? Does it stay in the node or go to the address you choose to receive rewards? Because on this address I don't notice any increase of GNO.**
 
-    If you have set a withdrawal address, your rewards will accrue in the deposit contract. At the moment you will have to claim them on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://gnosisscan.io/address/0x0b98057ea310f4d31f2a452b414647007d1645d9#writeProxyContract#F4) by calling the claimWithdrawals function and entering your withdrawal address
+    If you have set a withdrawal address, your rewards will accrue in the deposit contract. At the moment you will have to claim them on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial) by calling the claimWithdrawals function and entering your withdrawal address
 
 19. **I use Lighthouse and I wanted to know if it was possible to separate the rewards of each validator from the address provided when creating the keystore.json files? I also wanted to know if it was possible to add validators later**.
 
@@ -100,7 +100,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 21. **Can I withdraw my GNO which is currently used in validator?**
 
-    Yes, you have to do a [voluntary exit](https://docs.gnosischain.com/node/management/voluntary-exit) (either from the client itself or if you are on Dappnode from the Web3signer UI) then wait for your validator to leave the exit queue and once the withdrawal is ready claim on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://gnosisscan.io/address/0x0b98057ea310f4d31f2a452b414647007d1645d9#writeProxyContract#F4) by calling the claimWithdrawals function and entering your withdrawal address
+    Yes, you have to do a [voluntary exit](https://docs.gnosischain.com/node/management/voluntary-exit) (either from the client itself or if you are on Dappnode from the Web3signer UI) then wait for your validator to leave the exit queue and once the withdrawal is ready claim on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial) by calling the claimWithdrawals function and entering your withdrawal address
 
 22. **What is the easiest way to set withdrawal address without setting up locally beacon node, cli and etc.?**
 
@@ -134,11 +134,11 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
     You don't need to claim execution layer rewards who are paid in xDAI, when you propose a block, the reward will go to your address. You can see you rewards on [Gnosisscan](https://gnosisscan.io/) on your validator address, in the Validated Blocks tab.
 31. **Could anyone please explain to me how withdrawals and validator rewards work on Gnosis Chain?**
 
-    Consensus layer rewards are paid in GNO to your withdrawal address and have to be claimed on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial) ; Execution layer rewards are paid in xDAI to your recipient address. 
+    Consensus layer rewards are paid in GNO to your withdrawal address and have to be claimed on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial) ; Execution layer rewards are paid in xDAI to your recipient address. 
 
 31. **How to withdraw the staked validator amount though?**
 
-    You can do a [voluntary exit](https://docs.gnosischain.com/node/management/voluntary-exit) either from the client itself or if you are on Dappnode from the Web3signer UI then wait for your validator to leave the exit queue and once the withdrawal is ready claim on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
+    You can do a [voluntary exit](https://docs.gnosischain.com/node/management/voluntary-exit) either from the client itself or if you are on Dappnode from the Web3signer UI then wait for your validator to leave the exit queue and once the withdrawal is ready claim on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
 
 32. Is there a guide on how to withdraw when you only have the keystore?
 
@@ -146,7 +146,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 33. **I had partial withdrawals going to an address in August. Are the future withdrawals will go to the same address?**
 
-    If back then when a bot was claiming them automatically, your withdrawals were going to a specific address, it means that your withdrawal address is correctly setup and new withdrawals will go there as well. Now you have to claim withdrawals manually, you can do so on the [Deposit page](https://deposit.gnosischain.com/) or on the [Deposit contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial)
+    If back then when a bot was claiming them automatically, your withdrawals were going to a specific address, it means that your withdrawal address is correctly setup and new withdrawals will go there as well. Now you have to claim withdrawals manually, you can do so on the [Deposit page](https://validators.gnosischain.com/) or on the [Deposit contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial)
 
 34. **My wallet got hacked. Is there any way to change my withdrawal address?**
 
@@ -176,7 +176,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
     Currently not, even if Dappnode mentioned working on it in the past. You have to follow the regular [step by step guide](https://docs.gnosischain.com/node/management/withdrawals).
 41. **I see automatic withdrawals to my wallet on beaconchain.gnosischain.com, but I don't seem to be receiving them. Is there anything else that I need to do?**
 
-    You have to claim withdrawals manually, you can do so on the [Deposit page](https://deposit.gnosischain.com/) or on the Deposit contract. Once claimed it should be instantaneous in the same transaction.
+    You have to claim withdrawals manually, you can do so on the [Deposit page](https://validators.gnosischain.com/) or on the Deposit contract. Once claimed it should be instantaneous in the same transaction.
 
 42. **Should the automatic withdrawals that started after Shapella go to the default fee recipient address or some other address?**
 
@@ -184,7 +184,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 43. **What happened to automatic withdrawals after Shapella? How do I claim rewards manually?**
 
-    After the Shapella upgrade a bot was claiming withdrawals for everyone automatically but who was since then stopped after concerns about generating a lot of unsolicited small transactions who are complex to report for tax. You have to claim withdrawals manually now, you can do so on the [Deposit page](https://deposit.gnosischain.com/) or on the [Deposit contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
+    After the Shapella upgrade a bot was claiming withdrawals for everyone automatically but who was since then stopped after concerns about generating a lot of unsolicited small transactions who are complex to report for tax. You have to claim withdrawals manually now, you can do so on the [Deposit page](https://validators.gnosischain.com/) or on the [Deposit contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
 
 44. **Is there an easy way to transfer the ownership of my validators to a different address?**
 
@@ -204,7 +204,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 49. **I've got some validators, do I need to do something to receive the rewards from these validators to my wallet?**
 
-    Consensus layer rewards are paid in GNO to your withdrawal address and have to be claimed on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://deposit.gnosischain.com/) ; Execution layer rewards are paid in xDAI to your recipient address.
+    Consensus layer rewards are paid in GNO to your withdrawal address and have to be claimed on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial) ; Execution layer rewards are paid in xDAI to your recipient address.
 
 50. **What kind of penalties will I face if I am offline for 1 day?**
 
@@ -216,13 +216,13 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 52. **After withdrawals went live, I got some GNO in my wallet, but now there are no more coming in**
 
-    After the Shapella upgrade a bot was claiming withdrawals for everyone automatically but who was since then stopped after concerns about generating a lot of unsolicited small transactions who are complex to report for tax. You have to claim withdrawals manually now, you can do so on the [Deposit page](https://deposit.gnosischain.com/).
+    After the Shapella upgrade a bot was claiming withdrawals for everyone automatically but who was since then stopped after concerns about generating a lot of unsolicited small transactions who are complex to report for tax. You have to claim withdrawals manually now, you can do so on the [Deposit page](https://validators.gnosischain.com/).
 53. **My validator node is slashed, how to withdraw GNO?**
     You can do a voluntary exit either through the client like described in the docs or if you are using Dappnode you can exit through the Web3signer UI.
 
 54. **How long until withdrawals arrive in wallet?**
 
-    For full withdrawals you have to wait until your validator leaves the exit queue and be ready to claim. Then both for partial and full withdrawals, once claimed on the contract or on the [Deposit page](https://deposit.gnosischain.com/) it should be instantaneous.
+    For full withdrawals you have to wait until your validator leaves the exit queue and be ready to claim. Then both for partial and full withdrawals, once claimed on the contract or on the [Deposit page](https://validators.gnosischain.com/) it should be instantaneous.
 
 55. **On beaconchain.gnosischain.com while some rewards are denominated in GNO, others are in xDai. What's the difference?**
 
@@ -234,7 +234,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 57. **I see a withdrawal on beaconchain.gnosischain.com, but I haven't initiated anything. Why?**
 
-    The withdrawals you see on beaconchain.gnosischain.com are basically just withdrawals ready to be claimed on the contract, the GNO in question have waiting on the deposit contract, you can claim a withdrawal on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
+    The withdrawals you see on beaconchain.gnosischain.com are basically just withdrawals ready to be claimed on the contract, the GNO in question have waiting on the deposit contract, you can claim a withdrawal on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
 
 58. **I do not want partial withdrawals to be automatic due to tax reasons. Can I opt-out of this feature?**
 
@@ -242,7 +242,7 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 59. **I've been running my node for a week now. When/Where can I expect to start seeing my accrued rewards?**
 
-    If you have set a withdrawal address, your rewards will accrue in the deposit contract. At the moment you will have to claim them manually from that contract. You can either go and call claimWithdrawals function on the GBC deposit contract or use the Withdrawal Claim tab on https://deposit.gnosischain.com/. You can check your accrued rewards on https://beaconchain.gnosischain.com/ as well.
+    If you have set a withdrawal address, your rewards will accrue in the deposit contract. At the moment you will have to claim them manually from that contract. You can either go and call claimWithdrawals function on the GBC deposit contract or use the Withdrawal Claim tab on https://validators.gnosischain.com/. You can check your accrued rewards on https://beaconchain.gnosischain.com/ as well.
 
 60. **Can I withdraw without being online?**
 
@@ -273,12 +273,12 @@ It takes about 4 hours for a deposit to be processed, you can check how your val
 
 67. **I set a withdrawal address to a Safe on Gnosis Chain, I see the partial withdrawals, but the balance in GNO don’t go up. What should I do?**
 
-    Unlike Ethereum, on Gnosis Chain, you will have to claim them on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://deposit.gnosischain.com/) by calling the claimWithdrawals function and entering your withdrawal address
+    Unlike Ethereum, on Gnosis Chain, you will have to claim them on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial) by calling the claimWithdrawals function and entering your withdrawal address
 
 68. **Where do Withdrawals from Validators go to? After Update I received GNO once but now it says it's sending Amounts of GNO but they never arrive in my wallet.**
 
-    After the Shapella upgrade a bot was claiming withdrawals for everyone automatically but who was since then stopped after concerns about generating a lot of unsolicited small transactions who are complex to report for tax. You have to claim withdrawals manually now, you can do so on the [Deposit page](https://deposit.gnosischain.com/) or on the [Deposit contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial)
+    After the Shapella upgrade a bot was claiming withdrawals for everyone automatically but who was since then stopped after concerns about generating a lot of unsolicited small transactions who are complex to report for tax. You have to claim withdrawals manually now, you can do so on the [Deposit page](https://validators.gnosischain.com/) or on the [Deposit contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial)
 
 69. Is there a guide on how to unstake my Gnosis validators?
 
-    Do a [voluntary exit](https://docs.gnosischain.com/node/management/voluntary-exit) either from the client itself or if you are on Dappnode from the Web3signer UI then wait for your validator to leave the exit queue and once the withdrawal is ready claim on the [Deposit page](https://deposit.gnosischain.com/) or manually from the [contract](https://docs.gnosischain.com/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).
+    Do a [voluntary exit](https://docs.gnosischain.com/node/management/voluntary-exit) either from the client itself or if you are on Dappnode from the Web3signer UI then wait for your validator to leave the exit queue and once the withdrawal is ready claim on the [Deposit page](https://validators.gnosischain.com/) or manually from the [contract](/node/management/withdrawals#how-to-receive-my-withdrawal-full-or-partial).

--- a/docs/faq/Node FAQs/runningNode.md
+++ b/docs/faq/Node FAQs/runningNode.md
@@ -122,7 +122,7 @@ title: Running Nodes
 
 28. **If I have, say 100 GNO, can I put them all in a single validator to earn rewards on all 100, or must I run 100 separate validators of 1 each?**
 
-    The effective balance of a single validator is 1 GNO. All other GNO rewards accrued on your validator are ready to be claimed by calling the `claimWithdrawals function` on the GBC deposit contract or using the Withdrawal Claim tab on https://deposit.gnosischain.com/. If you have more than 1 GNO, you can set up multiple validators using the same machine.
+    The effective balance of a single validator is 1 GNO. All other GNO rewards accrued on your validator are ready to be claimed by calling the `claimWithdrawals function` on the GBC deposit contract or using the Withdrawal Claim tab on https://validators.gnosischain.com/. If you have more than 1 GNO, you can set up multiple validators using the same machine.
 
 29. **Can I participate in gnosis governance with GNO staked in validators? I would not think so, but if yes, how?**
 

--- a/docs/faq/node.md
+++ b/docs/faq/node.md
@@ -144,7 +144,7 @@ It depends on the mode and hardware specifications. Typically 24 hours should be
 
 8. Do partial withdrawals happen automatically?
 
-   The withdrawal processing itself is automatic once your validator is eligible. What is not automatic today is claiming the resulting GNO to the recipient address. After the withdrawal has been processed, you must claim it either on the [Deposit website](https://deposit.gnosischain.com/) or by calling [`claimWithdrawal`](https://gnosisscan.io/address/0x0B98057eA310F4d31F2a452B414647007d1645d9#writeProxyContract) or `claimWithdrawals(...)` on the deposit contract.
+   The withdrawal processing itself is automatic once your validator is eligible. What is not automatic today is claiming the resulting GNO to the recipient address. After the withdrawal has been processed, you must claim it either on the [Deposit website](https://validators.gnosischain.com/) or by calling [`claimWithdrawal`](https://gnosisscan.io/address/0x0B98057eA310F4d31F2a452B414647007d1645d9#writeProxyContract) or `claimWithdrawals(...)` on the deposit contract.
 
 9. Do full withdrawals happen automatically?
 
@@ -154,7 +154,7 @@ It depends on the mode and hardware specifications. Typically 24 hours should be
 
 10. Is there a UI that I can use for withdrawals?
 
-    Yes. You can claim withdrawals on the [Deposit website](https://deposit.gnosischain.com/). Advanced users can also claim directly through the deposit contract on Gnosis Chain.
+    Yes. You can claim withdrawals on the [Deposit website](https://validators.gnosischain.com/). Advanced users can also claim directly through the deposit contract on Gnosis Chain.
 
 11. Where does the automatic balance withdraw to?
 

--- a/docs/faq/others.md
+++ b/docs/faq/others.md
@@ -9,7 +9,7 @@
 
 2. What is Gnosis Faucet?
 
-   The Gnosis Chain xDAI faucet distributes xDAI to new users so that they may have enough gas to complete a few transactions and interact with applications on Gnosis Chain : https://www.gnosisfaucet.com/
+   The Gnosis Chain xDAI faucet distributes xDAI to new users so that they may have enough gas to complete a few transactions and interact with applications on Gnosis Chain : https://faucet.gnosischain.com/
 
 3. Where can I stake my GNO?
 
@@ -19,13 +19,11 @@
 
    When you stake your GNO on Stakewise you receive sGNO.
 
-https://docs.gnosischain.com/faq/others
-
-6. What is LGNO?
+5. What is LGNO?
 
    This stands for locked GNO. The LGNO contact was an incentive program for the Gnosis community to lock their GNO in return for vCOW. To learn more, please visit this thread by Stefan George -https://twitter.com/StefanDGeorge/status/1488924732191907849
 
-7. What is d14n.info?
+6. What is d14n.info?
 
    :::note
    The site is deprecated.
@@ -33,24 +31,20 @@ https://docs.gnosischain.com/faq/others
    [d14n.info](https://www.d14n.info/) is a real-time dashboard that measures decentralization of the Gnosis Chain and Ethereum networks. We use the Nakamoto Coefficient as the primary quantitative measure across multiple dimensions of the network.
    You may also check out [Gnosis Metrics](https://www.gnosismetrics.com/#overview)
 
-8. What native bridges does Gnosis have?
+7. What native bridges does Gnosis have?
 
    [xDAI & OmniBridge](https://docs.gnosischain.com/bridges/)
 
-9. What are the DAOs running on the Gnosis Chain?
+8. Which wallets can I use on the Gnosis Chain?
 
-    https://www.daosongnosis.com/
+    See [Wallets](../tools/wallets/README.md).
 
-10. Which wallets can I use on the Gnosis Chain?
-
-    https://www.gnosiswallets.com/
-
-11. How do I connect my wallet to Gnosis Chain?
+9. How do I connect my wallet to Gnosis Chain?
 
     Click 'Add to Metamask' in [here](https://docs.gnosischain.com/concepts/networks/mainnet) or view other options from
     https://docs.gnosischain.com/tools/wallets/
 
-12. I was staking xdai on the easystaking xdai site and it is no longer active. How can I access my xdai?
+10. I was staking xdai on the easystaking xdai site and it is no longer active. How can I access my xdai?
 
     This has been down for some time now due to the old team that was running xdai not maintain it anymore. You will need to use the block explorer to interact with the contracts without the UI in order for it to be withdrawn.
 
@@ -59,7 +53,7 @@ https://docs.gnosischain.com/faq/others
     https://etherscan.io/address/0xecbcd6d7264e3c9eac24c7130ed3cd2b38f5a7ad#readProxyContract 11. lastDepositIds Type your address which gives you a number. 3. balances Find your deposits. They are numbered from 0 up to the number you got previously. Check all of them.
     https://etherscan.io/address/0xecbcd6d7264e3c9eac24c7130ed3cd2b38f5a7ad#writeProxyContract 7. makeForcedWithdrawal Withdraw. Please note this instant-withdrawal has a 2% fee
 
-13. I recently transferred an ERC-1155 into a safe. I realized after the fact that gnosis does not support 1155s. Is there a way that I’m able to transfer it back out?
+11. I recently transferred an ERC-1155 into a safe. I realized after the fact that gnosis does not support 1155s. Is there a way that I’m able to transfer it back out?
 
     You have to use “contract interaction” on the safe when you click on “New Transaction”
     On the pop up, you will put in the contract address of the ERC-1155 token - (It may or may not automatically pull in the ABI so you may have to copy that from the contract details via gnosis scan)
@@ -76,53 +70,53 @@ https://docs.gnosischain.com/faq/others
     Add that transaction - then sign it off and that should work
     if you are still having issues i would suggest to hop into the Safe discord and ask for further assistance there.
 
-14. When SAFE airdrop?
+12. When SAFE airdrop?
 
     https://forum.gnosis.io/t/gip-64-should-gnosisdao-distribute-safe-tokens-to-incentivize-decentralizing-gnosis-chain/5896
     https://forum.gnosis.io/t/gip-64-should-gnosisdao-distribute-safe-tokens-to-incentivize-decentralizing-gnosis-chain/5896/54
 
-15. Where is the simplest way to stake GNO on gnosis chain?
+13. Where is the simplest way to stake GNO on gnosis chain?
 
     https://www.validategnosis.com/
 
-16. I’ve been experiencing this error withMetamask on Gnosis Chain. It doesn’t generate fees whenever I send tokens. ‘Transaction error - Internal JASON-RPC error.’
+14. I’ve been experiencing this error withMetamask on Gnosis Chain. It doesn’t generate fees whenever I send tokens. ‘Transaction error - Internal JASON-RPC error.’
 
     https://metamask.zendesk.com/hc/en-us/articles/360059289871-Error-Internal-JSON-RPC-error-when-trying-to-interact-with-other-network and please update your RPC on MetaMask to https://rpc.gnosis.gateway.fm/
 
-17. What is WXDAI for?
+15. What is WXDAI for?
 
     As xDai on Gnosis Chain acts similar to ETH on Ethereum Network, you would need a wrapped version of xDai to be used as an ERC-20. Basically, WXDAI is the equivalent of WETH on Gnosis Chain.
 
-18. What is Gnosis chain?
+16. What is Gnosis chain?
 
     Gnosis Chain is an EVM-based Layer 1 utilizing PoS consensus. Gnosis Chain utilizes a dual token model unlike similar EVM chains. On Gnosis Chain GNO token is used to secure the consensus layer while xDai is used as the gas token.
 
-19. How can I add Gnosis Chain to Metamask?
+17. How can I add Gnosis Chain to Metamask?
 
     You can follow the instructions on this page: https://docs.gnosischain.com/tools/wallets/metamask/
 
     Or alternatively, you can go to https://chainlist.org/ search for Gnosis Chain to get Gnosis Chain added automatically to your Metamask.
 
-20. What DApps can we use on Gnosis?
+18. What DApps can we use on Gnosis?
     All dApps on Gnosis Ecosystem can be found here:
     https://ecosystem.gnosischain.com/
 
-21. Is it possible run a Node and qualify for future rewards?
+19. Is it possible run a Node and qualify for future rewards?
 
     Yes, you can run a Node and qualify for rewards. For all the information you need in terms of running a node, please visit https://docs.gnosischain.com/node/.
 
-22. I’m totally new to this project and I’m trying to feel myself around. Where should I start learning?
+20. I’m totally new to this project and I’m trying to feel myself around. Where should I start learning?
 
     You can jump to all relevant links on our landing page at https://www.gnosis.io/. Alternatively, you can check our documentation https://docs.gnosischain.com/. Also, feel free to take a look at the governance forum to see what is being discussed around the community regarding improvement proposals https://forum.gnosis.io/.
 
-23. Is Gnosis Chain a Testnet or Mainnet released?
+21. Is Gnosis Chain a Testnet or Mainnet released?
 
     Gnosis Chain is not a testnet. It is a fully operational Layer 1 utilizing Proof of Stake. But if you are wondering, Gnosis Chain has its testnet called Chiado, the details of which can be found here: https://docs.gnosischain.com/concepts/networks/chiado.
 
-24. Is the grants program still running?
+22. Is the grants program still running?
 
     ‼️UPDATE: The Gnosis Ecosystem Fund was discontinued. Projects can now directly apply for funding through the GnosisDAO. For non commercial/public goods : https://bit.ly/gnosis-grants
 
-25. What are the NFT marketplaces on Gnosis Chain?
+23. What are the NFT marketplaces on Gnosis Chain?
 
     https://niftyfair.io/

--- a/docs/node/Node Tools/dappnode.md
+++ b/docs/node/Node Tools/dappnode.md
@@ -144,7 +144,7 @@ In case you need some xDai for transaction fees you can get some from the [Offic
 
 :::
 
-1. Navigate to: [https://deposit.gnosischain.com/](https://deposit.gnosischain.com/)
+1. Navigate to: [https://validators.gnosischain.com/](https://validators.gnosischain.com/)
 2. Connect your wallet.
 3. Upload the `deposit_data*.json` you generated with the key generator tool in Step 3.
 4. Your deposit file will be validated and list the number of validator deposits you are making and the required GNO to deposit. Click `Deposit` to continue.

--- a/docs/node/Node Tools/dappnode.md
+++ b/docs/node/Node Tools/dappnode.md
@@ -140,7 +140,7 @@ You are now ready to fund these validators and start validating.
 ### Step 4: Fund Your Validators
 
 :::tip
-In case you need some xDai for transaction fees you can get some from the [Official xDai faucet for Gnosis](https://gnosisfaucet.com/).
+In case you need some xDai for transaction fees you can get some from the [Official xDai faucet for Gnosis](https://faucet.gnosischain.com/).
 
 :::
 

--- a/docs/node/management/withdrawals.md
+++ b/docs/node/management/withdrawals.md
@@ -35,7 +35,7 @@ There are two kinds of withdrawals:
 
 ## What action should a validator take?
 
-### 1 · Check your withdrawal credential prefix
+### 1 · Check your withdrawal credential prefix {#check-withdrawal-credential}
 
 Gnosis Chain supports **two** execution‑address credential prefixes:
 
@@ -57,7 +57,7 @@ Gnosis Chain supports **two** execution‑address credential prefixes:
 
 ---
 
-### 2 · Change your credential (BLS‑to‑Execution)
+### 2 · Change your credential (BLS‑to‑Execution) {#how-to-change-the-withdrawal-credential}
 
 If you are on `0x00` *or* want to switch from `0x01` to `0x02`, perform a BLS‑to‑Execution change.
 
@@ -129,7 +129,7 @@ tar -xvf ethdo-<version>-linux-amd64.tar.gz
 
 ---
 
-## 3 · Claiming your GNO (partial **and** full withdrawals)
+## 3 · Claiming your GNO (partial **and** full withdrawals) {#how-to-receive-my-withdrawal-full-or-partial}
 
 Because Gnosis Chain pays out **GNO** rather than the gas token (xDai), withdrawals are **not sent automatically** to your address. After the Beacon‑chain message has executed you must *claim* the GNO from the withdrawal contract: [`0x0B98057eA310F4d31F2a452B414647007d1645d9`](https://gnosisscan.io/address/0x0B98057eA310F4d31F2a452B414647007d1645d9#writeProxyContract).
 

--- a/docs/node/manual/server/_partials/_jwt-generation-partial.md
+++ b/docs/node/manual/server/_partials/_jwt-generation-partial.md
@@ -14,10 +14,9 @@ openssl rand -hex 32 | tr -d "\n" > "./jwtsecret/jwt.hex"
     <summary>Other ways to generate the <code>jwt.hex</code> file</summary>
     
 
-2. Use an execution or consensus client to generate the `./jwtsecret/jwt.hex` file (check their documentation).
-3. Use an online generator like [this](https://seanwasere.com/generate-random-hex/). Copy and paste this value into a `./jwtsecret/jwt.hex` file.
+1. Use an execution or consensus client to generate the `./jwtsecret/jwt.hex` file (check their documentation).
 
-For options (1) and (3), create the file by running:
+If your client prints the token instead of writing the file, create the file by running:
 
 ```shell
 

--- a/docs/node/manual/validator/_partials/_verify-validator.md
+++ b/docs/node/manual/validator/_partials/_verify-validator.md
@@ -5,7 +5,7 @@ After [depositing](../deposit.md) and starting your validator, your validator wi
 
 You can verify the status of your validators following these steps:
 
-1. Navigate to the [deposit tool](https://deposit.gnosischain.com) and click on the `Validator Status` tab.
+1. Navigate to the [deposit tool](https://validators.gnosischain.com) and click on the `Validator Status` tab.
 
 <img src="/img/node/verify/verify-1.jpg" width="500" />
 <br />

--- a/docs/node/manual/validator/deposit.md
+++ b/docs/node/manual/validator/deposit.md
@@ -28,7 +28,7 @@ You can use [Transferto.xyz](https://transferto.xyz/) or the [Omnibridge](https:
 
 ### Step 1: Connect your Wallet
 
-1. Go to [https://deposit.gnosischain.com/](https://deposit.gnosischain.com) and connect your web3 wallet on the Gnosis Chain to the application.
+1. Go to [https://validators.gnosischain.com/](https://validators.gnosischain.com) and connect your web3 wallet on the Gnosis Chain to the application.
 
 In this example we use MetaMask.
 
@@ -183,64 +183,11 @@ It will take about 1.5 hours for your validators to start proposing and attestin
 - This is roughly 1 hour and 25 minutes before the validators start proposing and attesting blocks on the Gnosis Chain.
 - Once live, you can view your validator(s) on the explorer. Copy the pubkey(s) listed in the deposit_data.json file (a key will be generated for each validator as "pubkey": "&lt;your-public-key&gt;") and paste into the search box on the [Beacon chain explorer](https://beaconchain.gnosischain.com/).
 
-## Option 3: Running Your Own Deposit UI Instance Locally
+:::note Running your own instance
 
-### Step 1: Dependencies
-
-Ensure that you have [NodeJS](https://nodejs.org/en) and [npm](https://docs.npmjs.com/downloading-and-installing-node-js-and-npm) installed. 
-You can check the installation by running ```node -v``` and ```npm -v``` in your terminal.
-
-Additionally, install [Next.js](https://nextjs.org/) by running the command ```npm install next```.
-
-
-### Step 2: Download the Deposit UI from GitHub
-
-Download the Deposit UI files from the corresponding Gnosis Chain [GitHub Repo](https://github.com/gnosischain/gbc-deposit-ui/). Extract the ZIP file to wherever you want to.
-
-
-### Step 3: Edit Configuration Files
-
-1. Edit the file ```wagmi.ts``` in the ```main project folder```: change the **Mainnet RPC** to ```https://gnosis-rpc.publicnode.com``` on ```line 11``` (you may also choose another RPC, not all work)
-2. Edit the file ```fetchEvents.ts``` in the ```utils folder```: change the ```BLOCK_RANGE_SIZE``` to **```10000```** on ```line 6``` (previous value was ```1000000```)
-
-
-### Step 4: Run the UI
-
-1. Run the UI using the command ```npm run dev``` (in the main folder of the UI); if this doesn't work, it might need to be built or dependencies are missing try something like ```npm install typescript```.
-2. Open [http://localhost:3000/](http://localhost:3000/) in your browser, the UI should appear now if it all works correctly.
-
-
-### Step 5: Use the UI
-1. Connect your wallet and ensure you are connected on the right network (Gnosis Chain).
-2. Ensure that you have an adequate amount of GNO in your wallet to deposit to all pending validators listed in your ```deposit_data.json```.
-3. Add your ```deposit_data.json``` file to the UI once you're asked for it.
-4. Wait for the UI to load the completed deposits from the external RPC. Please have some patience as the RPC is rate limited.
-
-
-:::tip
-
-This process will take about 20 minutes. The UI will not show any progress for getting the blocks from the RPC once you've submitted your JSON file. If you use the browser console window (using right-click "Inspect"), you can see the block number going up though.
+Setup instructions live in the [consolidate-ui repository README](https://github.com/gnosischain/consolidate-ui#readme).
 
 :::
-
-
-### Step 6: Send Deposit Transactions
-
-For each validator in the file, a deposit transaction will be generated and sent to your wallet. Verify the transaction details (closer described in Option 1 above). Once verified, send out the transactions and wait for validator activation.
-
-
-### Step 7: Validator Activation
-
-:::tip
-
-It will take about 1.5 hours for your validators to start proposing and attesting to blocks.
-
-:::
-
-- Following a successful deposit, the Gnosis Beacon Chain will wait for 1024 Gnosis Chain blocks plus up to 64 Gnosis Beacon Chain epochs before adding validators to the pool.
-- This is roughly 1 hour and 25 minutes before the validators start proposing and attesting blocks on the Gnosis Chain.
-- Once live, you can view your validator(s) on the explorer. Copy the pubkey(s) listed in the deposit_data.json file (a key will be generated for each validator as "pubkey": "&lt;your-public-key&gt;") and paste into the search box on the [Beacon chain explorer](https://beaconchain.gnosischain.com/).
-
 
 
 ## Appendix
@@ -250,7 +197,4 @@ It will take about 1.5 hours for your validators to start proposing and attestin
 Required:
 
 1. Chiado Testnet xDai and GNO: https://faucet.gnosischain.com/?chain=chiado
-2. Connect to Deposit UI [https://deposit.gnosischain.com/](https://deposit.gnosischain.com) using Gnosis Chiado Testnet and follow the Option 1: Deposit UI.
-
-<!-- You can run the [deposit UI](https://deposit.gnosischain.com) locally following its repository `README` instructions:
-[https://github.com/gnosischain/gbc-deposit-ui#gnosis-beacon-chain-deposit-ui](https://github.com/gnosischain/gbc-deposit-ui#gnosis-beacon-chain-deposit-ui) -->
+2. Connect to Deposit UI [https://validators.gnosischain.com/](https://validators.gnosischain.com) using Gnosis Chiado Testnet and follow the Option 1: Deposit UI.

--- a/docs/node/manual/validator/deposit.md
+++ b/docs/node/manual/validator/deposit.md
@@ -249,7 +249,7 @@ It will take about 1.5 hours for your validators to start proposing and attestin
 
 Required:
 
-1. Chiado Testnet xDai and GNO: https://faucet.chiadochain.net/
+1. Chiado Testnet xDai and GNO: https://faucet.gnosischain.com/?chain=chiado
 2. Connect to Deposit UI [https://deposit.gnosischain.com/](https://deposit.gnosischain.com) using Gnosis Chiado Testnet and follow the Option 1: Deposit UI.
 
 <!-- You can run the [deposit UI](https://deposit.gnosischain.com) locally following its repository `README` instructions:

--- a/docs/node/rewards-penalties.md
+++ b/docs/node/rewards-penalties.md
@@ -59,7 +59,7 @@ Gnosis' rewards curve was [proposed in Nov 2021](https://forum.gnosis.io/t/launc
 
 ## Claiming Rewards
 
-You can claim your Gnosis Chain rewards on the [Deposit website](https://deposit.gnosischain.com/) or by manually calling the `claimWithdrawal(address)` or `claimWithdrawals(addresses)` method in the [Deposit contract](https://gnosisscan.io/address/0x0B98057eA310F4d31F2a452B414647007d1645d9#writeProxyContract).
+You can claim your Gnosis Chain rewards on the [Deposit website](https://validators.gnosischain.com/) or by manually calling the `claimWithdrawal(address)` or `claimWithdrawals(addresses)` method in the [Deposit contract](https://gnosisscan.io/address/0x0B98057eA310F4d31F2a452B414647007d1645d9#writeProxyContract).
 
 ![faucet](/img/node/withdrawal/claim-withdrawal.png)
 

--- a/docs/shutterized-gc/README.md
+++ b/docs/shutterized-gc/README.md
@@ -39,7 +39,7 @@ With the contribution from teams of [Shutter Network](https://shutter.network/),
 | Chain ID           | 100                              | 10200                                |
 | New RPC URL        | https://erpc.gnosis.shutter.network   | https://erpc.chiado.staging.shutter.network       |
 | Block Explorer     | https://gnosis.blockscout.com/        | https://blockscout.com/gnosis/chiado |
-| Faucet             | https://faucet.gnosischain.com/       | https://faucet.chiadochain.net/      |
+| Faucet             | https://faucet.gnosischain.com/       | https://faucet.gnosischain.com/?chain=chiado      |
 
 
 ### Shutterized Chiado Test dApp


### PR DESCRIPTION
## What

Several third-party destinations are no longer operated by the projects that originally ran them, so those links now point at official or first-party equivalents.